### PR TITLE
Fix deep slice not having a copy of path

### DIFF
--- a/diff.go
+++ b/diff.go
@@ -208,3 +208,12 @@ func are(a, b reflect.Value, kinds ...reflect.Kind) bool {
 
 	return amatch && bmatch
 }
+
+func copyAppend(src []string, elems ...string) []string {
+	dst := make([]string, len(src)+len(elems))
+	copy(dst, src)
+	for i := len(src); i < len(src)+len(elems); i++ {
+		dst[i] = elems[i-len(src)]
+	}
+	return dst
+}

--- a/diff_comparative.go
+++ b/diff_comparative.go
@@ -10,7 +10,7 @@ import (
 
 func (cl *Changelog) diffComparative(path []string, c *ComparativeList) error {
 	for _, k := range c.keys {
-		fpath := append(path, idstring(k))
+		fpath := copyAppend(path, idstring(k))
 
 		nv := reflect.ValueOf(nil)
 

--- a/diff_struct.go
+++ b/diff_struct.go
@@ -28,7 +28,7 @@ func (cl *Changelog) diffStruct(path []string, a, b reflect.Value) error {
 		af := a.Field(i)
 		bf := b.FieldByName(field.Name)
 
-		fpath := append(path, tname)
+		fpath := copyAppend(path, tname)
 
 		err := cl.diff(fpath, af, bf)
 		if err != nil {
@@ -68,7 +68,7 @@ func (cl *Changelog) structValues(t string, path []string, a reflect.Value) erro
 		af := a.Field(i)
 		xf := x.FieldByName(field.Name)
 
-		fpath := append(path, tname)
+		fpath := copyAppend(path, tname)
 
 		err := ncl.diff(fpath, xf, af)
 		if err != nil {

--- a/diff_test.go
+++ b/diff_test.go
@@ -19,6 +19,15 @@ type tuistruct struct {
 	Value int `diff:"value"`
 }
 
+type tnstruct struct {
+	Slice []tmstruct `diff:"slice"`
+}
+
+type tmstruct struct {
+	Foo string `diff:"foo"`
+	Bar int    `diff:"bar"`
+}
+
 type tstruct struct {
 	ID              string            `diff:"id,immutable"`
 	Name            string            `diff:"name"`
@@ -30,6 +39,7 @@ type tstruct struct {
 	Ignored         bool              `diff:"-"`
 	Identifiables   []tistruct        `diff:"identifiables"`
 	Unidentifiables []tuistruct       `diff:"unidentifiables"`
+	Nested          tnstruct          `diff:"nested"`
 }
 
 func sptr(s string) *string {
@@ -292,6 +302,16 @@ func TestDiff(t *testing.T) {
 		{
 			"omittable", tstruct{Ignored: false}, tstruct{Ignored: true},
 			Changelog{},
+			nil,
+		},
+		{
+			"slice", &tstruct{}, &tstruct{Nested: tnstruct{Slice: []tmstruct{{"one", 1}, {"two", 2}}}},
+			Changelog{
+				Change{Type: CREATE, Path: []string{"nested", "slice", "0", "foo"}, From: nil, To: "one"},
+				Change{Type: CREATE, Path: []string{"nested", "slice", "0", "bar"}, From: nil, To: 1},
+				Change{Type: CREATE, Path: []string{"nested", "slice", "1", "foo"}, From: nil, To: "two"},
+				Change{Type: CREATE, Path: []string{"nested", "slice", "1", "bar"}, From: nil, To: 2},
+			},
 			nil,
 		},
 	}


### PR DESCRIPTION
Adds test and fix for the following:
```
    --- FAIL: TestDiff/slice (0.00s)
        diff_test.go:328:
                Error Trace:    diff_test.go:328
                Error:          Not equal:
                                expected: []string{"nested", "slice", "0", "foo"}
                                actual  : []string{"nested", "slice", "0", "bar"}
                                Diff:
                                --- Expected
                                +++ Actual
                                @@ -4,3 +4,3 @@
                                  (string) (len=1) "0",
                                - (string) (len=3) "foo"
                                + (string) (len=3) "bar"
                                 }
                Test:           TestDiff/slice
        diff_test.go:328:
                Error Trace:    diff_test.go:328
                Error:          Not equal:
                                expected: []string{"nested", "slice", "1", "foo"}
                                actual  : []string{"nested", "slice", "1", "bar"}
                                Diff:
                                --- Expected
                                +++ Actual
                                @@ -4,3 +4,3 @@
                                  (string) (len=1) "1",
                                - (string) (len=3) "foo"
                                + (string) (len=3) "bar"
                                 }
                Test:           TestDiff/slice
```