### PR TITLE
Modify slice diffing to detect reordered slice items

### DIFF
--- a/diff_slice.go
+++ b/diff_slice.go
@@ -27,7 +27,7 @@ func (d *Differ) diffSliceGeneric(path []string, a, b reflect.Value) error {
 	for i := 0; i < a.Len(); i++ {
 		ae := a.Index(i)
 
-		if !slice.has(b, ae) {
+		if (d.SliceOrdering && !hasAtSameIndex(b, ae, i)) || (!d.SliceOrdering && !slice.has(b, ae)) {
 			missing.addA(i, &ae)
 		}
 	}
@@ -36,7 +36,7 @@ func (d *Differ) diffSliceGeneric(path []string, a, b reflect.Value) error {
 	for i := 0; i < b.Len(); i++ {
 		be := b.Index(i)
 
-		if !slice.has(a, be) {
+		if (d.SliceOrdering && !hasAtSameIndex(a, be, i)) || (!d.SliceOrdering && !slice.has(a, be)) {
 			missing.addB(i, &be)
 		}
 	}
@@ -108,4 +108,14 @@ func getFinalValue(t reflect.Value) reflect.Value {
 	default:
 		return t
 	}
+}
+
+func hasAtSameIndex(s, v reflect.Value, atIndex int) bool {
+	// check the element in the slice at atIndex to see if it matches value, if it is a valid index into the slice
+	if atIndex < s.Len() {
+		x := s.Index(atIndex)
+		return reflect.DeepEqual(x.Interface(), v.Interface())
+	}
+
+	return false
 }

--- a/options.go
+++ b/options.go
@@ -3,7 +3,7 @@ package diff
 // SliceOrdering determines whether the ordering of items in a slice results in a change
 func SliceOrdering(enabled bool) func(d *Differ) error {
 	return func(d *Differ) error {
-		d.SliceOrdering = true
+		d.SliceOrdering = enabled
 		return nil
 	}
 }


### PR DESCRIPTION
This changeset modifies slice comparison behavior to indicate
that slices are changing when items in the slice are reordered.
Previously, doing a comparison of two slices such as
`[]int{1,2,3}` and `[]int{1,3,2}` would result in no changelog being
generated.

Because this changes the logic used to compare slices, some slice
comparisons will now return different results.