### PR TITLE
compare time in millisecond level because of the accuracy lose caused…

### DIFF
--- a/diff_time.go
+++ b/diff_time.go
@@ -6,6 +6,7 @@ package diff
 
 import (
 	"reflect"
+	"time"
 )
 
 func (d *Differ) diffTime(path []string, a, b reflect.Value) error {
@@ -23,7 +24,10 @@ func (d *Differ) diffTime(path []string, a, b reflect.Value) error {
 		return ErrTypeMismatch
 	}
 
-	if a.Interface() != b.Interface() {
+	// Marshal and unmarshal time type will lose accuracy. Millisecond level accuracy may be enough.
+	ta, tb := a.Interface().(time.Time).Round(time.Millisecond), b.Interface().(time.Time).Round(time.Millisecond)
+
+	if ta != tb {
 		d.cl.add(UPDATE, path, a.Interface(), b.Interface())
 	}
 


### PR DESCRIPTION
```

var (
	now = time.Now()
)

type A struct {
	CreateTime time.Time `json:"createTime" diff:"createTime"`
}

func main() {
	a1 := A{
		CreateTime: now,
	}

	a2 := A{
		CreateTime: now,
	}

	data, err := json.Marshal(a2)
	if err != nil {
		log.Fatal(err)
	}

	json.Unmarshal(data, &a2)

	changelog, err := diff.Diff(a1, a2)
	if err != nil {
		log.Fatal(err)
	}

	fmt.Printf("%+v\n", changelog)
}

```
output:
```
[{Type:update Path:[createTime] From:2019-11-20 10:37:01.468951807 +0800 CST m=+0.000059503 To:2019-11-20 10:37:01.468951807 +
0800 CST}]
```

Marshal and umarshal time type will lose accuracy. Compare time in millisecond may be enough.