### PR TITLE
Support for custom differs

### DIFF
--- a/diff.go
+++ b/diff.go
@@ -256,7 +256,7 @@ func are(a, b reflect.Value, kinds ...reflect.Kind) bool {
 	return amatch && bmatch
 }
 
-func areType(a, b reflect.Value, types ...reflect.Type) bool {
+func AreType(a, b reflect.Value, types ...reflect.Type) bool {
 	var amatch, bmatch bool
 
 	for _, t := range types {

--- a/diff_bool.go
+++ b/diff_bool.go
@@ -8,12 +8,12 @@ import "reflect"
 
 func (d *Differ) diffBool(path []string, a, b reflect.Value) error {
 	if a.Kind() == reflect.Invalid {
-		d.cl.add(CREATE, path, nil, b.Interface())
+		d.cl.Add(CREATE, path, nil, b.Interface())
 		return nil
 	}
 
 	if b.Kind() == reflect.Invalid {
-		d.cl.add(DELETE, path, a.Interface(), nil)
+		d.cl.Add(DELETE, path, a.Interface(), nil)
 		return nil
 	}
 
@@ -22,7 +22,7 @@ func (d *Differ) diffBool(path []string, a, b reflect.Value) error {
 	}
 
 	if a.Bool() != b.Bool() {
-		d.cl.add(UPDATE, path, a.Interface(), b.Interface())
+		d.cl.Add(UPDATE, path, a.Interface(), b.Interface())
 	}
 
 	return nil

--- a/diff_float.go
+++ b/diff_float.go
@@ -10,12 +10,12 @@ import (
 
 func (d *Differ) diffFloat(path []string, a, b reflect.Value) error {
 	if a.Kind() == reflect.Invalid {
-		d.cl.add(CREATE, path, nil, b.Interface())
+		d.cl.Add(CREATE, path, nil, b.Interface())
 		return nil
 	}
 
 	if b.Kind() == reflect.Invalid {
-		d.cl.add(DELETE, path, a.Interface(), nil)
+		d.cl.Add(DELETE, path, a.Interface(), nil)
 		return nil
 	}
 
@@ -25,9 +25,9 @@ func (d *Differ) diffFloat(path []string, a, b reflect.Value) error {
 
 	if a.Float() != b.Float() {
 		if a.CanInterface() {
-			d.cl.add(UPDATE, path, a.Interface(), b.Interface())
+			d.cl.Add(UPDATE, path, a.Interface(), b.Interface())
 		} else {
-			d.cl.add(UPDATE, path, a.Float(), b.Float())
+			d.cl.Add(UPDATE, path, a.Float(), b.Float())
 		}
 	}
 

--- a/diff_int.go
+++ b/diff_int.go
@@ -10,12 +10,12 @@ import (
 
 func (d *Differ) diffInt(path []string, a, b reflect.Value) error {
 	if a.Kind() == reflect.Invalid {
-		d.cl.add(CREATE, path, nil, b.Interface())
+		d.cl.Add(CREATE, path, nil, b.Interface())
 		return nil
 	}
 
 	if b.Kind() == reflect.Invalid {
-		d.cl.add(DELETE, path, a.Interface(), nil)
+		d.cl.Add(DELETE, path, a.Interface(), nil)
 		return nil
 	}
 
@@ -25,9 +25,9 @@ func (d *Differ) diffInt(path []string, a, b reflect.Value) error {
 
 	if a.Int() != b.Int() {
 		if a.CanInterface() {
-			d.cl.add(UPDATE, path, a.Interface(), b.Interface())
+			d.cl.Add(UPDATE, path, a.Interface(), b.Interface())
 		} else {
-			d.cl.add(UPDATE, path, a.Int(), b.Int())
+			d.cl.Add(UPDATE, path, a.Int(), b.Int())
 		}
 	}
 

--- a/diff_interface.go
+++ b/diff_interface.go
@@ -8,12 +8,12 @@ import "reflect"
 
 func (d *Differ) diffInterface(path []string, a, b reflect.Value) error {
 	if a.Kind() == reflect.Invalid {
-		d.cl.add(CREATE, path, nil, b.Interface())
+		d.cl.Add(CREATE, path, nil, b.Interface())
 		return nil
 	}
 
 	if b.Kind() == reflect.Invalid {
-		d.cl.add(DELETE, path, a.Interface(), nil)
+		d.cl.Add(DELETE, path, a.Interface(), nil)
 		return nil
 	}
 
@@ -26,12 +26,12 @@ func (d *Differ) diffInterface(path []string, a, b reflect.Value) error {
 	}
 
 	if a.IsNil() {
-		d.cl.add(UPDATE, path, nil, b.Interface())
+		d.cl.Add(UPDATE, path, nil, b.Interface())
 		return nil
 	}
 
 	if b.IsNil() {
-		d.cl.add(UPDATE, path, a.Interface(), nil)
+		d.cl.Add(UPDATE, path, a.Interface(), nil)
 		return nil
 	}
 

--- a/diff_pointer.go
+++ b/diff_pointer.go
@@ -30,12 +30,12 @@ func (d *Differ) diffPtr(path []string, a, b reflect.Value) error {
 	}
 
 	if a.IsNil() {
-		d.cl.add(UPDATE, path, nil, b.Interface())
+		d.cl.Add(UPDATE, path, nil, b.Interface())
 		return nil
 	}
 
 	if b.IsNil() {
-		d.cl.add(UPDATE, path, a.Interface(), nil)
+		d.cl.Add(UPDATE, path, a.Interface(), nil)
 		return nil
 	}
 

--- a/diff_slice.go
+++ b/diff_slice.go
@@ -10,12 +10,12 @@ import (
 
 func (d *Differ) diffSlice(path []string, a, b reflect.Value) error {
 	if a.Kind() == reflect.Invalid {
-		d.cl.add(CREATE, path, nil, b.Interface())
+		d.cl.Add(CREATE, path, nil, b.Interface())
 		return nil
 	}
 
 	if b.Kind() == reflect.Invalid {
-		d.cl.add(DELETE, path, a.Interface(), nil)
+		d.cl.Add(DELETE, path, a.Interface(), nil)
 		return nil
 	}
 

--- a/diff_string.go
+++ b/diff_string.go
@@ -8,12 +8,12 @@ import "reflect"
 
 func (d *Differ) diffString(path []string, a, b reflect.Value) error {
 	if a.Kind() == reflect.Invalid {
-		d.cl.add(CREATE, path, nil, b.Interface())
+		d.cl.Add(CREATE, path, nil, b.Interface())
 		return nil
 	}
 
 	if b.Kind() == reflect.Invalid {
-		d.cl.add(DELETE, path, a.Interface(), nil)
+		d.cl.Add(DELETE, path, a.Interface(), nil)
 		return nil
 	}
 
@@ -22,7 +22,7 @@ func (d *Differ) diffString(path []string, a, b reflect.Value) error {
 	}
 
 	if a.String() != b.String() {
-		d.cl.add(UPDATE, path, a.String(), b.String())
+		d.cl.Add(UPDATE, path, a.String(), b.String())
 	}
 
 	return nil

--- a/diff_struct.go
+++ b/diff_struct.go
@@ -16,7 +16,7 @@ func (d *Differ) diffStruct(path []string, a, b reflect.Value) error {
 
 	if a.Kind() == reflect.Invalid {
 		if d.DisableStructValues {
-			d.cl.add(CREATE, path, nil, b.Interface())
+			d.cl.Add(CREATE, path, nil, b.Interface())
 			return nil
 		}
 		return d.structValues(CREATE, path, b)
@@ -24,7 +24,7 @@ func (d *Differ) diffStruct(path []string, a, b reflect.Value) error {
 
 	if b.Kind() == reflect.Invalid {
 		if d.DisableStructValues {
-			d.cl.add(DELETE, path, a.Interface(), nil)
+			d.cl.Add(DELETE, path, a.Interface(), nil)
 			return nil
 		}
 		return d.structValues(DELETE, path, a)

--- a/diff_struct.go
+++ b/diff_struct.go
@@ -10,7 +10,7 @@ import (
 )
 
 func (d *Differ) diffStruct(path []string, a, b reflect.Value) error {
-	if areType(a, b, reflect.TypeOf(time.Time{})) {
+	if AreType(a, b, reflect.TypeOf(time.Time{})) {
 		return d.diffTime(path, a, b)
 	}
 

--- a/diff_test.go
+++ b/diff_test.go
@@ -598,7 +598,7 @@ type testTypeDiffer struct{}
 func (testTypeDiffer) Match(a, b reflect.Value) bool {
 	return areType(a, b, reflect.TypeOf(testType("")))
 }
-func (testTypeDiffer) Diff(cl *MutableChangelog, path []string, a, b reflect.Value) error {
+func (testTypeDiffer) Diff(cl *Changelog, path []string, a, b reflect.Value) error {
 	if a.String() != "custom" && b.String() != "match" {
 		cl.Add(UPDATE, path, a.Interface(), b.Interface())
 	}

--- a/diff_test.go
+++ b/diff_test.go
@@ -596,7 +596,7 @@ type testType string
 type testTypeDiffer struct{}
 
 func (testTypeDiffer) Match(a, b reflect.Value) bool {
-	return areType(a, b, reflect.TypeOf(testType("")))
+	return AreType(a, b, reflect.TypeOf(testType("")))
 }
 func (testTypeDiffer) Diff(cl *Changelog, path []string, a, b reflect.Value) error {
 	if a.String() != "custom" && b.String() != "match" {

--- a/diff_time.go
+++ b/diff_time.go
@@ -11,12 +11,12 @@ import (
 
 func (d *Differ) diffTime(path []string, a, b reflect.Value) error {
 	if a.Kind() == reflect.Invalid {
-		d.cl.add(CREATE, path, nil, b.Interface())
+		d.cl.Add(CREATE, path, nil, b.Interface())
 		return nil
 	}
 
 	if b.Kind() == reflect.Invalid {
-		d.cl.add(DELETE, path, a.Interface(), nil)
+		d.cl.Add(DELETE, path, a.Interface(), nil)
 		return nil
 	}
 
@@ -29,7 +29,7 @@ func (d *Differ) diffTime(path []string, a, b reflect.Value) error {
 	bu := b.Interface().(time.Time).UnixNano()
 
 	if au != bu {
-		d.cl.add(UPDATE, path, a.Interface(), b.Interface())
+		d.cl.Add(UPDATE, path, a.Interface(), b.Interface())
 	}
 
 	return nil

--- a/diff_uint.go
+++ b/diff_uint.go
@@ -10,12 +10,12 @@ import (
 
 func (d *Differ) diffUint(path []string, a, b reflect.Value) error {
 	if a.Kind() == reflect.Invalid {
-		d.cl.add(CREATE, path, nil, b.Interface())
+		d.cl.Add(CREATE, path, nil, b.Interface())
 		return nil
 	}
 
 	if b.Kind() == reflect.Invalid {
-		d.cl.add(DELETE, path, a.Interface(), nil)
+		d.cl.Add(DELETE, path, a.Interface(), nil)
 		return nil
 	}
 
@@ -25,9 +25,9 @@ func (d *Differ) diffUint(path []string, a, b reflect.Value) error {
 
 	if a.Uint() != b.Uint() {
 		if a.CanInterface() {
-			d.cl.add(UPDATE, path, a.Interface(), b.Interface())
+			d.cl.Add(UPDATE, path, a.Interface(), b.Interface())
 		} else {
-			d.cl.add(UPDATE, path, a.Uint(), b.Uint())
+			d.cl.Add(UPDATE, path, a.Uint(), b.Uint())
 		}
 	}
 

--- a/options.go
+++ b/options.go
@@ -8,11 +8,19 @@ func SliceOrdering(enabled bool) func(d *Differ) error {
 	}
 }
 
-// DisableStructValues disables populating a seperate change for each item in a struct,
+// DisableStructValues disables populating a separate change for each item in a struct,
 // where the struct is being compared to a nil value
 func DisableStructValues() func(d *Differ) error {
 	return func(d *Differ) error {
 		d.DisableStructValues = true
+		return nil
+	}
+}
+
+// CustomValueDiffers allows you to register custom differs for specific types
+func CustomValueDiffers(vd ...ValueDiffer) func(d *Differ) error {
+	return func(d *Differ) error {
+		d.customValueDiffers = append(d.customValueDiffers, vd...)
 		return nil
 	}
 }


### PR DESCRIPTION
This PR adds support for defining custom diff functions.

The use case is to add custom diff functions for specific types (see test) or to extend support for unsupported types (e.g. [`uuid.UUID`](https://github.com/google/uuid) is currently not supported, also zero value needs special treatment). It could even be used to override default diff functions with custom ones.

Sidenote: The sole purpose of `MutableChangelog` is to expose the internal method `add` on `Changelog` without changing the interface of that type. The code could be a bit simpler if you decide to just expose `Changelog.add`.

Let me know if you want me to add an entry in the readme describing this feature.