### PR TITLE
New feature for custom differ - allows custom differs to pass control back to default differs. 

### DIFF
--- a/diff.go
+++ b/diff.go
@@ -51,6 +51,7 @@ type Change struct {
 type ValueDiffer interface {
 	Match(a, b reflect.Value) bool
 	Diff(cl *Changelog, path []string, a, b reflect.Value) error
+	InsertParentDiffer(dfunc func(path []string, a, b reflect.Value) error)
 }
 
 // Changed returns true if both values differ

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/r3labs/diff
+module github.com/nehbit/diff
 
 go 1.13
 

--- a/options.go
+++ b/options.go
@@ -21,6 +21,9 @@ func DisableStructValues() func(d *Differ) error {
 func CustomValueDiffers(vd ...ValueDiffer) func(d *Differ) error {
 	return func(d *Differ) error {
 		d.customValueDiffers = append(d.customValueDiffers, vd...)
+		for k, _ := range d.customValueDiffers {
+			d.customValueDiffers[k].InsertParentDiffer(d.diff)
+		}
 		return nil
 	}
 }


### PR DESCRIPTION
I was trying to create a custom differ for a struct that might have had other structs in it — it seems as it stands that is impossible. This allows custom differs to be used as intermediate steps. Essentially, as it stands, once you go into a custom differ, you can't ever go back — there is no way to pass the control back to the standard differs. This adds another method to the interface that diff.Differ uses to pass the internal diff() function into the custom differ. By calling that internal function, a custom differ can give back control, and diffing can continue normally.

A test case with a recursive struct (my use case) is also added, which uses this feature. In the test case, the custom differ gives back control to the slice differ, and slice differ in turn calls the custom differ again, so as to be able to deal with recursive trees.

Not sure if this works with your design, you might want to review it for your own purposes — there might be a better way of doing this. Mind that it does change how custom differs are delivered in as well, from a concrete value to a pointer. 

Lastly, make sure to remove the name change in the go.mod file. I had to push that out so I can use the changes myself, otherwise `go get` doesn't work. 🙂
