### PR TITLE
add filtering of struct fields

### DIFF
--- a/diff.go
+++ b/diff.go
@@ -36,6 +36,7 @@ type Differ struct {
 	customValueDiffers  []ValueDiffer
 	cl                  Changelog
 	AllowTypeMismatch   bool
+	Filter              FilterFunc
 }
 
 // Changelog stores a list of changed items
@@ -86,6 +87,11 @@ func NewDiffer(opts ...func(d *Differ) error) (*Differ, error) {
 
 	return &d, nil
 }
+
+// FilterFunc is a function that determines whether to descend into a struct field.
+// parent is the struct being examined and field is a field on that struct. path
+// is the path to the field from the root of the diff.
+type FilterFunc func(path []string, parent reflect.Type, field reflect.StructField) bool
 
 // StructValues gets all values from a struct
 // values are stored as "created" or "deleted" entries in the changelog,

--- a/diff_examples_test.go
+++ b/diff_examples_test.go
@@ -2,6 +2,7 @@ package diff
 
 import (
 	"fmt"
+	"reflect"
 )
 
 func ExampleDiff() {
@@ -62,4 +63,55 @@ func ExampleDiff() {
 
 	fmt.Printf("%#v", changelog)
 	// Produces: diff.Changelog{diff.Change{Type:"update", Path:[]string{"id"}, From:1, To:2}, diff.Change{Type:"update", Path:[]string{"name"}, From:"Green Apple", To:"Red Apple"}, diff.Change{Type:"create", Path:[]string{"nutrients", "2"}, From:interface {}(nil), To:"vitamin e"}, diff.Change{Type:"create", Path:[]string{"tags", "popularity"}, From:interface {}(nil), To:main.Tag{Name:"popularity", Value:"high"}}}
+}
+
+func ExampleFilter() {
+	type Tag struct {
+		Name  string `diff:"name,identifier"`
+		Value string `diff:"value"`
+	}
+
+	type Fruit struct {
+		ID        int      `diff:"id"`
+		Name      string   `diff:"name"`
+		Healthy   bool     `diff:"healthy"`
+		Nutrients []string `diff:"nutrients"`
+		Tags      []Tag    `diff:"tags"`
+	}
+
+	a := Fruit{
+		ID:      1,
+		Name:    "Green Apple",
+		Healthy: true,
+		Nutrients: []string{
+			"vitamin c",
+			"vitamin d",
+		},
+	}
+
+	b := Fruit{
+		ID:      2,
+		Name:    "Red Apple",
+		Healthy: true,
+		Nutrients: []string{
+			"vitamin c",
+			"vitamin d",
+			"vitamin e",
+		},
+	}
+
+	d, err := NewDiffer(Filter(func(path []string, parent reflect.Type, field reflect.StructField) bool {
+		return field.Name != "Name"
+	}))
+	if err != nil {
+		panic(err)
+	}
+
+	changelog, err := d.Diff(a, b)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("%#v", changelog)
+	// Output: diff.Changelog{diff.Change{Type:"update", Path:[]string{"id"}, From:1, To:2}, diff.Change{Type:"create", Path:[]string{"nutrients", "2"}, From:interface {}(nil), To:"vitamin e"}}
 }

--- a/diff_struct.go
+++ b/diff_struct.go
@@ -47,6 +47,10 @@ func (d *Differ) diffStruct(path []string, a, b reflect.Value) error {
 
 		fpath := copyAppend(path, tname)
 
+		if d.Filter != nil && !d.Filter(fpath, a.Type(), field) {
+			continue
+		}
+
 		err := d.diff(fpath, af, bf)
 		if err != nil {
 			return err

--- a/options.go
+++ b/options.go
@@ -43,3 +43,11 @@ func AllowTypeMismatch(enabled bool) func(d *Differ) error {
 		return nil
 	}
 }
+
+// Filter allows you to determine which fields the differ descends into
+func Filter(f FilterFunc) func(d *Differ) error {
+	return func(d *Differ) error {
+		d.Filter = f
+		return nil
+	}
+}


### PR DESCRIPTION
This pr adds a new option `Filter`, which can be used like this

```
d, err := diff.NewDiffer(diff.Filter(func (path []string, parent reflect.Type, field reflect.StructField) bool {
  // return true to descend into the field, false to ignore it
}))
```

The `parent` argument will contain the type information for the struct being examined, and the `field` argument will contain the struct field being examined.

Closes #37 