### PR TITLE
Patch / Merge

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@
 
 # Project-local glide cache, RE: https://github.com/Masterminds/glide/issues/736
 .glide/
+
+patchflags_string.go

--- a/change_value.go
+++ b/change_value.go
@@ -1,0 +1,154 @@
+package diff
+
+import (
+	"reflect"
+)
+
+//Not strictly necessary but migh be nice in some cases
+//go:generate stringer -type=PatchFlags
+type PatchFlags uint32
+const (
+	OptionCreate PatchFlags = 1 << iota
+	OptionOmitUnequal
+	FlagInvalidTarget
+	FlagApplied
+	FlagFailed
+	FlagCreated
+	FlagIgnored
+	FlagDeleted
+	FlagUpdated
+)
+
+//ChangeValue is a specialized struct for monitoring patching
+type ChangeValue struct {
+	val    reflect.Value
+	flags  PatchFlags
+	change *Change
+	err    error
+	index  int
+	key    reflect.Value
+}
+
+//PatchLogEntry defines how a DiffLog entry was applied
+type PatchLogEntry struct{
+	Path  []string    `json:"path"`
+	From  interface{} `json:"from"`
+	To    interface{} `json:"to"`
+	Flags PatchFlags  `json:"flags"`
+	Errors error      `json:"errors"`
+}
+type PatchLog []PatchLogEntry
+
+//NewChangeValue idiomatic constructor
+func NewChangeValue(c Change, target interface{}) *ChangeValue{
+	return &ChangeValue{
+		val:    reflect.ValueOf(target),
+		change: &c,
+	}
+}
+
+//NewPatchLogEntry converts our complicated reflection based struct to
+//a simpler format for the consumer
+func NewPatchLogEntry(change *ChangeValue) PatchLogEntry {
+	return PatchLogEntry{
+		Path: change.change.Path,
+		From: change.change.From,
+		To: change.change.To,
+		Flags: change.flags,
+		Errors: change.err,
+	}
+}
+
+// Sets a flag on the node and saves the change
+func (c *ChangeValue) SetFlag(flag PatchFlags) {
+	if c != nil {
+		c.flags = c.flags|flag
+	}
+}
+
+//ClearFlag Clears a flag on the node and saves the change
+func (c *ChangeValue) ClearFlags(){
+	if c != nil {c.flags = 0}
+}
+
+//HasFlag indicates if a flag is set on the node. returns false if node is bad
+func (c *ChangeValue) HasFlag(flag PatchFlags) bool {
+	return (c.flags & flag) != 0
+}
+
+//CanSet echos the reflection can set
+func (c ChangeValue) CanSet() bool {
+	return c.val.CanSet()
+}
+
+//IsValid echo for is valid
+func (c *ChangeValue) IsValid() bool {
+	if c != nil {return c.val.IsValid() || !c.HasFlag(FlagInvalidTarget)}
+	return false
+}
+
+//Len echo for len
+func (c ChangeValue) Len() int {
+	return c.val.Len()
+}
+
+//Kind echos the reflection kind
+func (c ChangeValue) Kind() reflect.Kind {
+	return c.val.Kind()
+}
+
+//Type echos Type
+func (c ChangeValue) Type() reflect.Type {
+	return c.val.Type()
+}
+
+//Set echos reflect set
+func (c *ChangeValue) Set(value reflect.Value){
+	if c != nil {
+		defer func() {
+			if r := recover(); r != nil {
+				c.SetFlag(FlagFailed)
+			}
+		}()
+		c.val.Set(value)
+		c.SetFlag(FlagApplied)
+	}
+}
+
+//SetMapValue is used to set a map value
+func (c *ChangeValue) SetMapValue(key reflect.Value, value reflect.Value){
+	if c != nil {
+		defer func() {
+			if r := recover(); r != nil {
+				c.SetFlag(FlagFailed)
+			}
+		}()
+		c.val.SetMapIndex(key, value)
+	}
+}
+
+//Index echo for index
+func (c ChangeValue) Index(i int) reflect.Value {
+	return c.val.Index(i)
+}
+
+//Interface gets the interface for the value
+func (c ChangeValue) Interface() interface{} {
+	return c.val.Interface()
+}
+
+//IsNil echo for is nil
+func (c ChangeValue) IsNil() bool {
+	return c.val.IsNil()
+}
+
+//KeyType returns the key type of a map if it is one
+func (c ChangeValue) KeyType() reflect.Type {
+	return c.Type().Key()
+}
+
+//AddError appends errors to this change value
+func (c *ChangeValue) AddError(err error) *ChangeValue{
+	if c != nil {c.err = err}
+	return c
+}

--- a/diff.go
+++ b/diff.go
@@ -12,13 +12,6 @@ import (
 	"strings"
 )
 
-var (
-	// ErrTypeMismatch Compared types do not match
-	ErrTypeMismatch = errors.New("types do not match")
-	// ErrInvalidChangeType The specified change values are not unsupported
-	ErrInvalidChangeType = errors.New("change type must be one of 'create' or 'delete'")
-)
-
 const (
 	// CREATE represents when an element has been added
 	CREATE = "create"

--- a/diff_examples_test.go
+++ b/diff_examples_test.go
@@ -5,6 +5,228 @@ import (
 	"reflect"
 )
 
+//Try to do a bunch of stuff that will result in some or all failures
+//when trying to apply either a valid or invalid changelog
+func ExamplePatchWithErrors(){
+
+	type Fruit struct {
+		ID        int      `diff:"ID" json:"Identifier"`
+		Name      string   `diff:"name"`
+		Healthy   bool     `diff:"-"`
+		Nutrients []string `diff:"nutrients"`
+		Labels    map[string]int `diff:"labs"`
+	}
+
+	type Bat struct {
+		ID string `diff:"ID"`
+		Name string `diff:"-"`
+	}
+
+	a := Fruit{
+		ID:      1,
+		Name:    "Green Apple",
+		Healthy: true,
+		Nutrients: []string{
+			"vitamin a",
+			"vitamin b",
+			"vitamin c",
+			"vitamin d",
+		},
+		Labels: make(map[string]int),
+	}
+	a.Labels["likes"] = 10
+	a.Labels["colors"] = 2
+
+	b := Fruit{
+		ID:      2,
+		Name:    "Red Apple",
+		Healthy: true,
+		Nutrients: []string{
+			"vitamin c",
+			"vitamin d",
+			"vitamin e",
+		},
+		Labels: make(map[string]int),
+	}
+	b.Labels["forests"] = 1223
+	b.Labels["colors"] = 1222
+
+	c := Fruit{
+		Labels: make(map[string]int),
+		Nutrients: []string{
+			"vitamin c",
+			"vitamin d",
+			"vitamin a",
+		},
+	}
+	c.Labels["likes"] = 21
+	c.Labels["colors"] = 42
+
+	d := Bat{
+		ID: "first",
+		Name: "second",
+	}
+
+	changelog, err := Diff(a, b)
+	if err != nil {
+		panic(err)
+	}
+
+	//This fails in total because c is not assignable (passed by value)
+	patchLog := Patch(changelog, c)
+
+	//this also demonstrated the nested errors with 'next'
+	errors := patchLog[7].Errors.(*DiffError)
+
+	//we can also continue to nest errors if we like
+	message := errors.WithCause(NewError("This is a custom message")).
+		              WithCause(fmt.Errorf("this is an error from somewhere else but still compatible")).
+		              Error()
+
+	//invoke a few failures, i.e. bad changelog
+	changelog[2].Path[1] = "bad index"
+	changelog[3].Path[0] = "bad struct field"
+
+	patchLog = Patch(changelog, &c)
+
+	patchLog, _ = Merge(a,nil, &c)
+
+	patchLog, _ = Merge(a, d, &c)
+
+	//try patching a string
+	patchLog = Patch(changelog, message)
+
+	//test an invalid change value
+	var bad *ChangeValue
+	if bad.IsValid() {
+		fmt.Print("this should never happen")
+	}
+
+	//Output:
+}
+
+//ExampleMerge demonstrates how to use the Merge function
+func ExampleMerge() {
+	type Fruit struct {
+		ID        int      `diff:"ID" json:"Identifier"`
+		Name      string   `diff:"name"`
+		Healthy   bool     `diff:"healthy"`
+		Nutrients []string `diff:"nutrients,create,omitunequal"`
+		Labels    map[string]int `diff:"labs,create"`
+	}
+
+	a := Fruit{
+		ID:      1,
+		Name:    "Green Apple",
+		Healthy: true,
+		Nutrients: []string{
+			"vitamin a",
+			"vitamin b",
+			"vitamin c",
+			"vitamin d",
+		},
+		Labels: make(map[string]int),
+	}
+	a.Labels["likes"] = 10
+	a.Labels["colors"] = 2
+
+	b := Fruit{
+		ID:      2,
+		Name:    "Red Apple",
+		Healthy: true,
+		Nutrients: []string{
+			"vitamin c",
+			"vitamin d",
+			"vitamin e",
+		},
+		Labels: make(map[string]int),
+	}
+	b.Labels["forests"] = 1223
+	b.Labels["colors"] = 1222
+
+	c := Fruit{
+		Labels: make(map[string]int),
+		Nutrients: []string{
+			"vitamin a",
+			"vitamin c",
+			"vitamin d",
+		},
+	}
+	c.Labels["likes"] = 21
+	c.Labels["colors"] = 42
+
+	//the only error that can happen here comes from the diff step
+	patchLog, _ := Merge(a,b, &c)
+
+	//Note that unlike our patch version we've not included 'create' in the
+	//tag for nutrients. This will omit "vitamin e" from ending up in c
+	fmt.Printf("%#v", len(patchLog))
+
+	//Output: 8
+}
+
+//ExamplePatch demonstrates how to use the Patch function
+func ExamplePatch(){
+
+	type Fruit struct {
+		ID        int      `diff:"ID" json:"Identifier"`
+		Name      string   `diff:"name"`
+		Healthy   bool     `diff:"healthy"`
+		Nutrients []string `diff:"nutrients,create,omitunequal"`
+		Labels    map[string]int `diff:"labs,create"`
+	}
+
+	a := Fruit{
+		ID:      1,
+		Name:    "Green Apple",
+		Healthy: true,
+		Nutrients: []string{
+			"vitamin a",
+			"vitamin b",
+			"vitamin c",
+			"vitamin d",
+		},
+		Labels: make(map[string]int),
+	}
+	a.Labels["likes"] = 10
+	a.Labels["colors"] = 2
+
+	b := Fruit{
+		ID:      2,
+		Name:    "Red Apple",
+		Healthy: true,
+		Nutrients: []string{
+			"vitamin c",
+			"vitamin d",
+			"vitamin e",
+		},
+		Labels: make(map[string]int),
+	}
+	b.Labels["forests"] = 1223
+	b.Labels["colors"] = 1222
+
+	c := Fruit{
+		Labels: make(map[string]int),
+		Nutrients: []string{
+			"vitamin a",
+			"vitamin c",
+			"vitamin d",
+		},
+	}
+	c.Labels["likes"] = 21
+
+	changelog, err := Diff(a, b)
+	if err != nil {
+		panic(err)
+	}
+
+	patchLog := Patch(changelog, &c)
+
+	fmt.Printf("%#v", len(patchLog))
+
+	//Output: 8
+}
+
 func ExampleDiff() {
 	type Tag struct {
 		Name  string `diff:"name,identifier"`

--- a/error.go
+++ b/error.go
@@ -1,0 +1,74 @@
+package diff
+
+import (
+	"fmt"
+)
+
+var (
+	// ErrTypeMismatch Compared types do not match
+	ErrTypeMismatch = NewError("types do not match")
+	// ErrInvalidChangeType The specified change values are not unsupported
+	ErrInvalidChangeType = NewError("change type must be one of 'create' or 'delete'")
+)
+
+//our own version of an error, which can wrap others
+type DiffError struct {
+	count   int
+	message string
+	next    error
+}
+
+//Unwrap implement 1.13 unwrap feature for compatibility
+func(s *DiffError) Unwrap() error {
+	return s.next
+}
+
+//Error implements the error interface
+func (s DiffError) Error() string {
+	cause := ""
+	if s.next != nil {
+		cause = s.next.Error()
+	}
+	return fmt.Sprintf(" %s (cause count %d)\n%s", s.message, s.count, cause)
+}
+
+//AppendCause appends a new cause error to the chain
+func (s *DiffError) WithCause(err error) *DiffError {
+	if s != nil && err != nil {
+		s.count++
+		if s.next != nil {
+			if v, ok := err.(DiffError); ok {
+				s.next = v.WithCause(s.next)
+			} else if v, ok := err.(*DiffError); ok {
+				s.next = v.WithCause(s.next)
+			} else {
+				v = &DiffError{
+					message: "auto wrapped error",
+					next:    err,
+				}
+				s.next = v.WithCause(s.next)
+			}
+		} else {
+			s.next = err
+		}
+	}
+	return s
+}
+
+//NewErrorf just give me a plain error with formatting
+func NewErrorf(format string, messages ...interface{}) *DiffError {
+	return &DiffError{
+		message: fmt.Sprintf(format, messages...),
+	}
+}
+
+//NewError just give me a plain error
+func NewError(message string, causes ...error) *DiffError {
+	s := &DiffError{
+		message: message,
+	}
+	for _, cause := range causes {
+		s.WithCause(cause)
+	}
+	return s
+}

--- a/patch.go
+++ b/patch.go
@@ -1,0 +1,273 @@
+package diff
+
+import (
+	"reflect"
+	"strconv"
+)
+
+/**
+	This is a method of applying a changelog to a value or struct. change logs
+    should be generated with Diff and never manually created. This DOES NOT
+    apply fuzzy logic as would be in the case of a text patch. It does however
+    have a few additional features added to our struct tags.
+
+	1) create. This tag on a struct field indicates that the patch should
+       create the value if it's not there. I.e. if it's nil. This works for
+       pointers, maps and slices.
+
+	2) omitunequal. Generally, you don't want to do this, the expectation is
+       that if an item isn't there, you want to add it. For example, if your
+       diff shows an array element at index 6 is a string 'hello' but your target
+       only has 3 elements, none of them matching... you want to add 'hello'
+       regardless of the index. (think in a distributed context, another process
+       may have deleted more than one entry and 'hello' may no longer be in that
+       indexed spot.
+
+       So given this scenario, the default behavior is to scan for the previous
+       value and replace it anyway, or simply append the new value. For maps the
+       default behavior is to simply add the key if it doesn't match.
+
+       However, if you don't like the default behavior, and add the omitunequal
+       tag to your struct, patch will *NOT* update an array or map with the key
+       or array value unless they key or index contains a 'match' to the
+       previous value. In which case it will skip over that change.
+
+    Patch is implemented as a best effort algorithm. That means you can receive
+    multiple nested errors and still successfully have a modified target. This
+    may even be acceptable depending on your use case. So keep in mind, just
+    because err != nil *DOESN'T* mean that the patch didn't accomplish your goal
+    in setting those changes that are actually available. For example, you may
+    diff two structs of the same type, then attempt to apply to an entirely
+    different struct that is similar in constitution (think interface here) and
+    you may in fact get all of the values populated you wished to anyway.
+ */
+
+// Merge is a convenience function that diffs, the original and changed items
+// and merges said changes with target all in one call.
+func Merge(original interface{}, changed interface{}, target interface{}) (PatchLog, error) {
+	if cl, err := Diff(original, changed); err == nil {
+		return Patch(cl, target), nil
+	}else{
+		return nil, err
+	}
+}
+
+//Patch... the missing feature.
+func Patch(cl Changelog, target interface{}) (ret PatchLog) {
+	for _, c := range cl {
+		ret = append(ret, NewPatchLogEntry(patch(NewChangeValue(c, target))))
+	}
+	return ret
+}
+
+//patch apply an individual change as opposed to a change log
+func patch(c *ChangeValue) (cv *ChangeValue){
+
+	//Can be messy to clean up when doing reflection
+	defer func() {
+		if r := recover(); r != nil {
+			cv.AddError(NewError("cannot set values on target",
+				NewError("passed by value not reference")))
+			cv.SetFlag(FlagInvalidTarget)
+		}
+	}()
+	cv = c
+	cv.val = cv.val.Elem()
+
+	//resolve where we're actually going to set this value
+	cv.index = -1
+	if cv.Kind() == reflect.Struct { //substitute and solve for t (path)
+		for _, p := range cv.change.Path {
+			if cv.Kind() == reflect.Slice {
+				//field better be an index of the slice
+				if cv.index, cv.err = strconv.Atoi(p); cv.err != nil {
+					return cv.AddError(NewErrorf("invalid index in path: %s", p).
+						WithCause(cv.err))
+				}
+				break //last item in a path that's a slice is it's index
+			}
+			if cv.Kind() == reflect.Map {
+				keytype := cv.KeyType()
+				cv.key = reflect.ValueOf(p)
+				cv.key.Convert(keytype)
+				break //same as a slice
+			}
+			cv = renderTargetField(cv, p)
+		}
+	}
+
+	//we have to know that the new element we're trying to set is valid
+	if !cv.CanSet(){
+		cv.SetFlag(FlagInvalidTarget)
+		return cv.AddError(NewError("cannot set values on target",
+			NewError("passed by value not reference")))
+	}
+
+	switch cv.change.Type {
+	case DELETE:
+		deleteOperation(cv)
+	case UPDATE, CREATE:
+		updateOperation(cv)
+	}
+	return cv
+}
+
+//renderTargetField this interrogates the path and returns the correct value to
+//change. Note that his is a recursion, t is not the same value as ret
+func renderTargetField(t *ChangeValue, field string) (ret *ChangeValue) {
+	ret = t
+	//substitute and solve for t (path)
+	switch t.val.Kind() {
+	case reflect.Struct:
+		for i := 0; i < t.val.NumField(); i++ {
+			f := t.val.Type().Field(i)
+			tname := tagName("diff", f)
+			if tname == "-" || hasTagOption("diff", f, "immutable") {
+				continue
+			}
+			if tname == field || f.Name == field{
+				ret = &ChangeValue{
+					val:    t.val.Field(i),
+					change: t.change,
+				}
+				ret.ClearFlags()
+				if hasTagOption("diff", f, "create") {
+					ret.SetFlag(OptionCreate)
+				}
+				if hasTagOption("diff", f, "omitunequal"){
+					ret.SetFlag(OptionOmitUnequal)
+				}
+			}
+		}
+	default:
+		ret = &ChangeValue{
+			val:    t.val,
+			change: t.change,
+		}
+	}
+	if !ret.IsValid() {
+		ret.AddError(NewErrorf("Unable to access path value %v. Target field is invalid", field))
+	}
+	return
+}
+
+//deleteOperation takes out some of the cyclomatic complexity from the patch fuction
+func deleteOperation(cv *ChangeValue) {
+	switch cv.Kind() {
+	case reflect.Slice:
+		var x reflect.Value
+		if cv.Len() > cv.index {
+			x = cv.Index(cv.index)
+		}
+		found := true
+		if !x.IsValid() || !reflect.DeepEqual(x.Interface(), cv.change.From) {
+			found = false
+			if !cv.HasFlag(OptionOmitUnequal){
+				cv.AddError(NewErrorf("value index %d is invalid", cv.index).
+					WithCause(NewError("scanning for value index")))
+				for i := 0; i < cv.Len(); i++ {
+					x = cv.Index(i)
+					if reflect.DeepEqual(x, cv.change.From) {
+						cv.AddError(NewErrorf("value changed index to %d", i))
+						found = true
+						cv.index = i
+					}
+				}
+			}
+		}
+		if x.IsValid() && found{
+			cv.val.Index(cv.index).Set(cv.val.Index(cv.Len() - 1))
+			cv.val.Set(cv.val.Slice(0, cv.Len() - 1))
+			cv.SetFlag(FlagDeleted)
+		}else{
+			cv.SetFlag(FlagIgnored)
+			cv.AddError(NewError("Unable to find matching slice index entry"))
+		}
+	case reflect.Map:
+		if !reflect.DeepEqual(cv.change.From, cv.Interface()) &&
+			cv.HasFlag(OptionOmitUnequal){
+			cv.SetFlag(FlagIgnored)
+			cv.AddError(NewError("target change doesn't match original"))
+			return
+		}
+		if cv.IsNil() {
+			cv.SetFlag(FlagIgnored)
+			cv.AddError(NewError("target has nil map nothing to delete"))
+			return
+		}else{
+			cv.SetFlag(FlagDeleted)
+			cv.SetMapValue(cv.key, reflect.Value{})
+		}
+	default:
+		cv.Set(reflect.Zero(cv.Type()))
+		cv.SetFlag(FlagDeleted)
+	}
+}
+
+//updateOperation takes out some of the cyclomatic complexity from the patch fuction
+func updateOperation(cv *ChangeValue) {
+	switch cv.Kind() {
+	case reflect.Slice:
+		var x reflect.Value
+		if cv.Len() > cv.index {
+			x = cv.Index(cv.index)
+		}
+		found := true
+		if !x.IsValid() || !reflect.DeepEqual(x.Interface(), cv.change.From) {
+			found = false
+			if !cv.HasFlag(OptionOmitUnequal){
+				cv.AddError(NewErrorf("value index %d is invalid", cv.index).
+						    WithCause(NewError("scanning for value index")))
+				for i := 0; i < cv.Len(); i++ {
+					x = cv.Index(i)
+					if reflect.DeepEqual(x, cv.change.From) {
+						cv.AddError(NewErrorf("value changed index to %d", i))
+						found = true
+					}
+				}
+			}
+		}
+		if x.IsValid() && found{
+			x.Set(reflect.ValueOf(cv.change.To))
+			cv.SetFlag(FlagUpdated)
+		}else if cv.HasFlag(OptionCreate) && cv.change.Type == CREATE {
+			cv.Set(reflect.Append(cv.val, reflect.ValueOf(cv.change.To)))
+			cv.SetFlag(FlagCreated)
+		}else{
+			cv.AddError(NewError("Unable to find matching slice index entry"))
+			cv.SetFlag(FlagIgnored)
+		}
+	case reflect.Map:
+		if !reflect.DeepEqual(cv.change.From, cv.Interface()) &&
+			cv.HasFlag(OptionOmitUnequal){
+			cv.SetFlag(FlagIgnored)
+			cv.AddError(NewError("target change doesn't match original"))
+			return
+		}
+		if cv.IsNil() {
+			if cv.HasFlag(OptionCreate) {
+				nm := reflect.MakeMap(cv.Type())
+				nm.SetMapIndex(cv.key, reflect.ValueOf(cv.change.To))
+				cv.Set(nm)
+				cv.SetFlag(FlagCreated)
+			}else{
+				cv.SetFlag(FlagIgnored)
+				cv.AddError(NewError("target has nil map and create not set"))
+				return
+			}
+		}else{
+			cv.SetFlag(FlagUpdated)
+			cv.SetMapValue(cv.key, reflect.ValueOf(cv.change.To))
+		}
+	default:
+		if !reflect.DeepEqual(cv.change.From, cv.Interface()) &&
+			cv.HasFlag(OptionOmitUnequal){
+			cv.SetFlag(FlagIgnored)
+			cv.AddError(NewError("target change doesn't match original"))
+			return
+		}
+		cv.Set(reflect.ValueOf(cv.change.To))
+		cv.SetFlag(FlagUpdated)
+	}
+}
+


### PR DESCRIPTION
My first attempt at a Patch / Merge implementation for Diff's change log format.

Folded into diff's source tree. Features include:

- Patch function which takes a change log and a pointer to a target
- Merge function which takes origin and changed values as well as  a pointer to a target
- produces a PatchLog, similar to a ChangeLog in which what action  was taken is described
- Offers a couple of struct tag additions that affect how patch  applies changes, these include:
  - omitunequal, which applies the strict rule that the target value must match the origin value or it will not get replaced
  - create, which allows for the creation of map and slice elements should they not already be present
- Patch honors the "-" name in the diff tag's name portion. thus excluding said strut member from updates
- Patch honors the diff struct tags 'name' and will apply the change to the target member or map appropriately.
- There are examples in diff_examples-_test.go These help maintain the code bases unit test coverage percentage
- There is a new error utility, which allows for nested link lists of errors in a special type.
- The business of patching is fuzzy and errors don't necessarily mean the operation failed so patch is a 'best effort' operation and will fulfill all the changes in the change lot to the target as best it can. Audit / errors are contained in the PatchLog

Test pass and code coverage remains above 80%
![Screen Shot 2020-08-17 at 1 45 28 PM](https://user-images.githubusercontent.com/1952419/90427073-0874b480-e090-11ea-886e-fafbf08a37b2.png)

A simple usage example:
![Screen Shot 2020-08-17 at 2 00 20 PM](https://user-images.githubusercontent.com/1952419/90428485-10355880-e092-11ea-9e16-4aaeceae8231.png)
