### PR TITLE
修复切片数据索引位置交换导致的bug

### DIFF
--- a/diff_slice.go
+++ b/diff_slice.go
@@ -36,8 +36,7 @@ func (d *Differ) diffSliceGeneric(path []string, a, b reflect.Value) error {
 	slice := sliceTracker{}
 	for i := 0; i < a.Len(); i++ {
 		ae := a.Index(i)
-
-		if (d.SliceOrdering && !hasAtSameIndex(b, ae, i)) || (!d.SliceOrdering && !slice.has(b, ae)) {
+		if (d.SliceOrdering && !hasAtSameIndex(b, ae, i)) || (!d.SliceOrdering && !slice.has(b, ae, i)) {
 			missing.addA(i, &ae)
 		}
 	}
@@ -45,8 +44,7 @@ func (d *Differ) diffSliceGeneric(path []string, a, b reflect.Value) error {
 	slice = sliceTracker{}
 	for i := 0; i < b.Len(); i++ {
 		be := b.Index(i)
-
-		if (d.SliceOrdering && !hasAtSameIndex(a, be, i)) || (!d.SliceOrdering && !slice.has(a, be)) {
+		if (d.SliceOrdering && !hasAtSameIndex(a, be, i)) || (!d.SliceOrdering && !slice.has(a, be, i)) {
 			missing.addB(i, &be)
 		}
 	}
@@ -88,7 +86,7 @@ func (d *Differ) diffSliceComparative(path []string, a, b reflect.Value) error {
 // keeps track of elements that have already been matched, to stop duplicate matches from occurring
 type sliceTracker []bool
 
-func (st *sliceTracker) has(s, v reflect.Value) bool {
+func (st *sliceTracker) has(s, v reflect.Value, index int) bool {
 	if len(*st) != s.Len() {
 		(*st) = make([]bool, s.Len(), s.Len())
 	}
@@ -100,7 +98,7 @@ func (st *sliceTracker) has(s, v reflect.Value) bool {
 		}
 
 		x := s.Index(i)
-		if reflect.DeepEqual(x.Interface(), v.Interface()) {
+		if reflect.DeepEqual(x.Interface(), v.Interface()) && i == index {
 			(*st)[i] = true
 			return true
 		}


### PR DESCRIPTION
```go
[]string{"web.business.image/202009165d0d6aeb03ec6ecb494897d8", "web.business.image/202009045d0d1788b05942ca42988dca"}

[]string{"web.business.image/202009045d0d1788b05942ca42988dca", "web.business.image/202009165d0d6aeb03ec6ecb494897d8"}
```

fix index exchange diff error


no index will output type :

```
from :web.business.image/202009165d0d6aeb03ec6ecb494897d8,to:<nil>,path: []string{"xxx", "xxx", "1"},type:delete
from :<nil>,to:web.business.image/202009045d0d25b79ba5011f438dafb7,path: []string{"xxx", "xxx", "0"},type:create
```