### PR TITLE
Fix flagging change as immutable when finding a field that has "-" ta…

### DIFF
--- a/patch_struct.go
+++ b/patch_struct.go
@@ -15,8 +15,7 @@ func (c *ChangeValue) patchStruct() {
 	for i := 0; i < c.target.NumField(); i++ {
 		f := c.target.Type().Field(i)
 		tname := tagName("diff", f)
-		if tname == "-" || hasTagOption("diff", f, "immutable") {
-			c.SetFlag(OptionImmutable)
+		if tname == "-" {
 			continue
 		}
 		if tname == field || f.Name == field {
@@ -26,6 +25,9 @@ func (c *ChangeValue) patchStruct() {
 			}
 			if hasTagOption("diff", f, "omitunequal") {
 				c.SetFlag(OptionOmitUnequal)
+			}
+			if hasTagOption("diff", f, "immutable") {
+				c.SetFlag(OptionImmutable)
 			}
 			c.swap(&x)
 			break


### PR DESCRIPTION
…g before the actual field

There is an error when flagging a field with a "-" tag in combination with patching, so that a patch to a field is not applied although it should be. Here's an example of the current behavior:

```
package main

import (
	"fmt"

	"github.com/r3labs/diff/v2"
)

type A struct {
	F1 string `diff:"-"`
	F2 string
}

type B struct {
	F1 string
	F2 string
}

func main() {
	a1 := A{
		F1: "test",
		F2: "value1",
	}
	a2 := A{
		F1: "test",
		F2: "value2",
	}

	la, _ := diff.Diff(&a1, &a2)
	diff.Patch(la, &a1)
	fmt.Printf("%s\n", a1.F2) // should print "value2", but prints "value1"

	b1 := B{
		F1: "test",
		F2: "value1",
	}
	b2 := B{
		F1: "test",
		F2: "value2",
	}

	lb, _ := diff.Diff(&b1, &b2)
	diff.Patch(lb, &b1)
	fmt.Printf("%s", b1.F2) // works as expected
}
```

The problem is: when the field tagged with "-" is found before the actual field to patch, the whole change is flagged "immutable", see [patch_struct.go](https://github.com/r3labs/diff/blob/d02c561d30fcf9200509ddc9cb8c8994841652d6/patch_struct.go#L18)

The PR fixes that behavior.