### PR TITLE
Make Patch a method on Differ, so we can specify custom TagName

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,22 +247,22 @@ type Order struct {
 }
 
 func main() {
-	a := Order{
-		ID:    "1234",
-		Items: []int{1, 2, 3, 4},
-	}
+    a := Order{
+        ID:    "1234",
+        Items: []int{1, 2, 3, 4},
+        }
 
-	b := Order{
-		ID:    "1234",
-		Items: []int{1, 2, 4},
-	}
+    b := Order{
+        ID:    "1234",
+        Items: []int{1, 2, 4},
+    }
 
     d, _ := diff.NewDiffer(diff.TagName("json"))
 
     changelog, _ := d.Diff(a, b)
 
-	d.Patch(changelog, &a)
-	// reflect.DeepEqual(a, b) == true
+    d.Patch(changelog, &a)
+    // reflect.DeepEqual(a, b) == true
 }
 
 ```

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ A diffable value can be/contain any of the following types:
 
 
 | Type         | Supported |
-|--------------|-----------|
+| ------------ | --------- |
 | struct       | ✔         |
 | slice        | ✔         |
 | string       | ✔         |
@@ -69,12 +69,12 @@ Please see the docs for more supported types, options and features.
 
 In order for struct fields to be compared, they must be tagged with a given name. All tag values are prefixed with `diff`. i.e. `diff:"items"`.
 
-| Tag          | Usage                              |
-|--------------|------------------------------------|
-| `-`          | Excludes a value from being diffed |
-| `identifier` | If you need to compare arrays by a matching identifier and not based on order, you can specify the `identifier` tag. If an identifiable element is found in both the from and to structures, they will be directly compared. i.e. `diff:"name, identifier"` |
-| `immutable` | Will omit this struct field from diffing. When using `diff.StructValues()` these values will be added to the returned changelog. It's use case is for when we have nothing to compare a struct to and want to show all of its relevant values. |
-| `nocreate` | The default patch action is to allocate instances in the target strut, map or slice should they not exist. Adding this flag will tell patch to skip elements that it would otherwise need to allocate. This is separate from immutable, which is also honored while patching. |
+| Tag           | Usage                                                                                                                                                                                                                                                                                           |
+| ------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `-`           | Excludes a value from being diffed                                                                                                                                                                                                                                                              |
+| `identifier`  | If you need to compare arrays by a matching identifier and not based on order, you can specify the `identifier` tag. If an identifiable element is found in both the from and to structures, they will be directly compared. i.e. `diff:"name, identifier"`                                     |
+| `immutable`   | Will omit this struct field from diffing. When using `diff.StructValues()` these values will be added to the returned changelog. It's use case is for when we have nothing to compare a struct to and want to show all of its relevant values.                                                  |
+| `nocreate`    | The default patch action is to allocate instances in the target strut, map or slice should they not exist. Adding this flag will tell patch to skip elements that it would otherwise need to allocate. This is separate from immutable, which is also honored while patching.                   |
 | `omitunequal` | Patching is a 'best effort' operation, and will by default attempt to update the 'correct' member of the target even if the underlying value has already changed to something other than the value in the change log 'from'. This tag will selectively ignore values that are not a 100% match. |
 
 ## Usage
@@ -84,7 +84,7 @@ In order for struct fields to be compared, they must be tagged with a given name
 Diffing a basic set of values can be accomplished using the diff functions. Any items that specify a "diff" tag using a name will be compared.
 
 ```go
-import "github.com/r3labs/diff"
+import "github.com/r3labs/diff/v2"
 
 type Order struct {
     ID    string `diff:"id"`
@@ -125,7 +125,7 @@ When marshalling the changelog to json, the output will look like:
 
 Options can be set on the differ at call time which effect how diff acts when building the change log.
 ```go
-import "github.com/r3labs/diff"
+import "github.com/r3labs/diff/v2"
 
 type Order struct {
     ID    string `diff:"id"`
@@ -151,7 +151,7 @@ func main() {
 You can also create a new instance of a differ that allows options to be set.
 
 ```go
-import "github.com/r3labs/diff"
+import "github.com/r3labs/diff/v2"
 
 type Order struct {
     ID    string `diff:"id"`
@@ -205,7 +205,7 @@ To accommodate this patch keeps track of each change log option it attempts to a
 happened for further scrutiny.
 
 ```go
-import "github.com/r3labs/diff"
+import "github.com/r3labs/diff/v2"
 
 type Order struct {
     ID    string `diff:"id"`
@@ -234,11 +234,44 @@ func main() {
 }
 ```
 
+Instances of differ with options set can also be used when patching.
+
+```go
+package main
+
+import "github.com/r3labs/diff/v2"
+
+type Order struct {
+	ID    string `json:"id"`
+	Items []int  `json:"items"`
+}
+
+func main() {
+	a := Order{
+		ID:    "1234",
+		Items: []int{1, 2, 3, 4},
+	}
+
+	b := Order{
+		ID:    "1234",
+		Items: []int{1, 2, 4},
+	}
+
+    d, _ := diff.NewDiffer(diff.TagName("json"))
+
+    changelog, _ := d.Diff(a, b)
+    
+	d.Patch(changelog, &a)
+	// reflect.DeepEqual(a, b) == true
+}
+
+```
+
 As a convenience, there is a Merge function that allows one to take three interfaces and perform all the tasks at the same
 time.
 
 ```go
-import "github.com/r3labs/diff"
+import "github.com/r3labs/diff/v2"
 
 type Order struct {
     ID    string `diff:"id"`

--- a/README.md
+++ b/README.md
@@ -169,10 +169,10 @@ func main() {
         Items: []int{1, 2, 4},
     }
 
-	d, err := diff.NewDiffer(diff.SliceOrdering(true))
-	if err != nil {
-		panic(err)
-	}
+    d, err := diff.NewDiffer(diff.SliceOrdering(true))
+    if err != nil {
+        panic(err)
+    }
 
     changelog, err := d.Diff(a, b)
     ...
@@ -260,7 +260,7 @@ func main() {
     d, _ := diff.NewDiffer(diff.TagName("json"))
 
     changelog, _ := d.Diff(a, b)
-    
+
 	d.Patch(changelog, &a)
 	// reflect.DeepEqual(a, b) == true
 }

--- a/patch_map.go
+++ b/patch_map.go
@@ -1,12 +1,13 @@
 package diff
 
 import (
-	"github.com/vmihailenco/msgpack"
 	"reflect"
+
+	"github.com/vmihailenco/msgpack"
 )
 
 //renderMap - handle map rendering for patch
-func (c *ChangeValue) renderMap() (m, k, v *reflect.Value) {
+func (d *Differ) renderMap(c *ChangeValue) (m, k, v *reflect.Value) {
 
 	//we must tease out the type of the key, we use the msgpack from diff to recreate the key
 	kt := c.target.Type().Key()
@@ -47,7 +48,7 @@ func (c *ChangeValue) renderMap() (m, k, v *reflect.Value) {
 //deleteMapEntry - deletes are special, they are handled differently based on options
 //            container type etc. We have to have special handling for each
 //            type. Set values are more generic even if they must be instanced
-func (c *ChangeValue) deleteMapEntry(m, k, v *reflect.Value) {
+func (d *Differ) deleteMapEntry(c *ChangeValue, m, k, v *reflect.Value) {
 	if m != nil && m.CanSet() && v.IsValid() {
 		for x := 0; x < v.NumField(); x++ {
 			if !v.Field(x).IsZero() {

--- a/patch_slice.go
+++ b/patch_slice.go
@@ -10,7 +10,7 @@ import (
 )
 
 //renderSlice - handle slice rendering for patch
-func (c *ChangeValue) renderSlice() {
+func (d *Differ) renderSlice(c *ChangeValue) {
 
 	var err error
 	field := c.change.Path[c.pos]
@@ -50,7 +50,7 @@ func (c *ChangeValue) renderSlice() {
 //deleteSliceEntry - deletes are special, they are handled differently based on options
 //              container type etc. We have to have special handling for each
 //              type. Set values are more generic even if they must be instanced
-func (c *ChangeValue) deleteSliceEntry() {
+func (d *Differ) deleteSliceEntry(c *ChangeValue) {
 	//for a slice with only one element
 	if c.ParentLen() == 1 && c.index != -1 {
 		c.ParentSet(reflect.MakeSlice(c.parent.Type(), 0, 0))

--- a/patch_struct.go
+++ b/patch_struct.go
@@ -8,25 +8,25 @@ import "reflect"
 */
 
 //patchStruct - handles the rendering of a struct field
-func (c *ChangeValue) patchStruct() {
+func (d *Differ) patchStruct(c *ChangeValue) {
 
 	field := c.change.Path[c.pos]
 
 	for i := 0; i < c.target.NumField(); i++ {
 		f := c.target.Type().Field(i)
-		tname := tagName("diff", f)
+		tname := tagName(d.TagName, f)
 		if tname == "-" {
 			continue
 		}
 		if tname == field || f.Name == field {
 			x := c.target.Field(i)
-			if hasTagOption("diff", f, "nocreate") {
+			if hasTagOption(d.TagName, f, "nocreate") {
 				c.SetFlag(OptionNoCreate)
 			}
-			if hasTagOption("diff", f, "omitunequal") {
+			if hasTagOption(d.TagName, f, "omitunequal") {
 				c.SetFlag(OptionOmitUnequal)
 			}
-			if hasTagOption("diff", f, "immutable") {
+			if hasTagOption(d.TagName, f, "immutable") {
 				c.SetFlag(OptionImmutable)
 			}
 			c.swap(&x)
@@ -36,7 +36,7 @@ func (c *ChangeValue) patchStruct() {
 }
 
 //track and zero out struct members
-func (c *ChangeValue) deleteStructEntry() {
+func (d *Differ) deleteStructEntry(c *ChangeValue) {
 
 	//deleting a struct value set's it to the 'basic' type
 	c.Set(reflect.Zero(c.target.Type()))


### PR DESCRIPTION
When using custom TagName when generating diff, it's useful to be able to also use custom TagName when calling `Patch()`. I'm not sure if it makes sense to have `render*`-methods on the `Differ` instance instead of on the `ChangeValue`, but at least it accomplishes what I was after. What do you guys think?