### PR TITLE
Add option to flatten embedded structs

### DIFF
--- a/diff.go
+++ b/diff.go
@@ -7,10 +7,11 @@ package diff
 import (
 	"errors"
 	"fmt"
-	"github.com/vmihailenco/msgpack"
 	"reflect"
 	"strconv"
 	"strings"
+
+	"github.com/vmihailenco/msgpack"
 )
 
 const (
@@ -24,15 +25,16 @@ const (
 
 // Differ a configurable diff instance
 type Differ struct {
-	TagName             string
-	SliceOrdering       bool
-	DisableStructValues bool
-	customValueDiffers  []ValueDiffer
-	cl                  Changelog
-	AllowTypeMismatch   bool
-	DiscardParent       bool
-	StructMapKeys       bool
-	Filter              FilterFunc
+	TagName                string
+	SliceOrdering          bool
+	DisableStructValues    bool
+	customValueDiffers     []ValueDiffer
+	cl                     Changelog
+	AllowTypeMismatch      bool
+	DiscardParent          bool
+	StructMapKeys          bool
+	FlattenEmbeddedStructs bool
+	Filter                 FilterFunc
 }
 
 // Changelog stores a list of changed items

--- a/diff_struct.go
+++ b/diff_struct.go
@@ -45,7 +45,10 @@ func (d *Differ) diffStruct(path []string, a, b reflect.Value) error {
 		af := a.Field(i)
 		bf := b.FieldByName(field.Name)
 
-		fpath := copyAppend(path, tname)
+		fpath := path
+		if !field.Anonymous {
+			fpath = copyAppend(fpath, tname)
+		}
 
 		if d.Filter != nil && !d.Filter(fpath, a.Type(), field) {
 			continue

--- a/diff_test.go
+++ b/diff_test.go
@@ -36,13 +36,13 @@ type tmstruct struct {
 	Bar int    `diff:"bar"`
 }
 
-type Tmstruct struct {
+type Embedded struct {
 	Foo string `diff:"foo"`
 	Bar int    `diff:"bar"`
 }
 
 type embedstruct struct {
-	Tmstruct
+	Embedded
 	Baz bool `diff:"baz"`
 }
 
@@ -407,8 +407,8 @@ func TestDiff(t *testing.T) {
 		},
 		{
 			"embedded-struct-field",
-			embedstruct{Tmstruct{Foo: "a", Bar: 2}, true},
-			embedstruct{Tmstruct{Foo: "b", Bar: 3}, false},
+			embedstruct{Embedded{Foo: "a", Bar: 2}, true},
+			embedstruct{Embedded{Foo: "b", Bar: 3}, false},
 			Changelog{
 				Change{Type: UPDATE, Path: []string{"foo"}, From: "a", To: "b"},
 				Change{Type: UPDATE, Path: []string{"bar"}, From: 2, To: 3},

--- a/diff_test.go
+++ b/diff_test.go
@@ -36,6 +36,16 @@ type tmstruct struct {
 	Bar int    `diff:"bar"`
 }
 
+type Tmstruct struct {
+	Foo string `diff:"foo"`
+	Bar int    `diff:"bar"`
+}
+
+type embedstruct struct {
+	Tmstruct
+	Baz bool `diff:"baz"`
+}
+
 type tstruct struct {
 	ID              string            `diff:"id,immutable"`
 	Name            string            `diff:"name"`
@@ -392,6 +402,17 @@ func TestDiff(t *testing.T) {
 			tstruct{private: 4},
 			Changelog{
 				Change{Type: UPDATE, Path: []string{"private"}, From: int64(1), To: int64(4)},
+			},
+			nil,
+		},
+		{
+			"embedded-struct-field",
+			embedstruct{Tmstruct{Foo: "a", Bar: 2}, true},
+			embedstruct{Tmstruct{Foo: "b", Bar: 3}, false},
+			Changelog{
+				Change{Type: UPDATE, Path: []string{"foo"}, From: "a", To: "b"},
+				Change{Type: UPDATE, Path: []string{"bar"}, From: 2, To: 3},
+				Change{Type: UPDATE, Path: []string{"baz"}, From: true, To: false},
 			},
 			nil,
 		},

--- a/options.go
+++ b/options.go
@@ -1,5 +1,13 @@
 package diff
 
+// FlattenEmbeddedStructs determines whether fields of embedded structs should behave as if they are directly under the parent
+func FlattenEmbeddedStructs(enabled bool) func(d *Differ) error {
+	return func(d *Differ) error {
+		d.FlattenEmbeddedStructs = enabled
+		return nil
+	}
+}
+
 // SliceOrdering determines whether the ordering of items in a slice results in a change
 func SliceOrdering(enabled bool) func(d *Differ) error {
 	return func(d *Differ) error {

--- a/patch_struct.go
+++ b/patch_struct.go
@@ -7,19 +7,42 @@ import "reflect"
     in place. Keeps the file simpler as well.
 */
 
+type structField struct {
+	f reflect.StructField
+	v reflect.Value
+}
+
+func getNestedFields(v reflect.Value, flattenEmbedded bool) []structField {
+	fields := make([]structField, 0)
+
+	for i := 0; i < v.NumField(); i++ {
+		f := v.Type().Field(i)
+		fv := v.Field(i)
+
+		if fv.Kind() == reflect.Struct && f.Anonymous && flattenEmbedded {
+			fields = append(fields, getNestedFields(fv, flattenEmbedded)...)
+		} else {
+			fields = append(fields, structField{f, fv})
+		}
+	}
+
+	return fields
+}
+
 //patchStruct - handles the rendering of a struct field
 func (d *Differ) patchStruct(c *ChangeValue) {
 
 	field := c.change.Path[c.pos]
 
-	for i := 0; i < c.target.NumField(); i++ {
-		f := c.target.Type().Field(i)
+	structFields := getNestedFields(*c.target, d.FlattenEmbeddedStructs)
+	for _, structField := range structFields {
+		f := structField.f
 		tname := tagName(d.TagName, f)
 		if tname == "-" {
 			continue
 		}
 		if tname == field || f.Name == field {
-			x := c.target.Field(i)
+			x := structField.v
 			if hasTagOption(d.TagName, f, "nocreate") {
 				c.SetFlag(OptionNoCreate)
 			}

--- a/patch_test.go
+++ b/patch_test.go
@@ -81,22 +81,6 @@ func TestPatch(t *testing.T) {
 			},
 			nil,
 		},
-		// {
-		// 	"comparable-slice-insert", &[]tistruct{{"one", 1}}, &[]tistruct{{"one", 1}, {"two", 2}},
-		// 	Changelog{
-		// 		Change{Type: CREATE, Path: []string{"two", "name"}, To: "two"},
-		// 		Change{Type: CREATE, Path: []string{"two", "value"}, To: 2},
-		// 	},
-		// 	nil,
-		// },
-		// {
-		// 	"comparable-slice-delete", &[]tistruct{{"one", 1}, {"two", 2}}, &[]tistruct{{"one", 1}},
-		// 	Changelog{
-		// 		Change{Type: DELETE, Path: []string{"two", "name"}, From: "two"},
-		// 		Change{Type: DELETE, Path: []string{"two", "value"}, From: 2},
-		// 	},
-		// 	nil,
-		// },
 		{
 			"comparable-slice-update", &[]tistruct{{"one", 1}}, &[]tistruct{{"one", 50}},
 			Changelog{
@@ -104,97 +88,6 @@ func TestPatch(t *testing.T) {
 			},
 			nil,
 		},
-		// {
-		// 	"map-slice-insert", &[]map[string]string{{"test": "123"}}, &[]map[string]string{{"test": "123", "tset": "456"}},
-		// 	Changelog{
-		// 		Change{Type: CREATE, Path: []string{"0", "tset"}, To: "456"},
-		// 	},
-		// 	nil,
-		// },
-		// {
-		// 	"map-slice-update", &[]map[string]string{{"test": "123"}}, &[]map[string]string{{"test": "456"}},
-		// 	Changelog{
-		// 		Change{Type: UPDATE, Path: []string{"0", "test"}, From: "123", To: "456"},
-		// 	},
-		// 	nil,
-		// },
-		// {
-		// 	"map-slice-delete", &[]map[string]string{{"test": "123", "tset": "456"}}, &[]map[string]string{{"test": "123"}},
-		// 	Changelog{
-		// 		Change{Type: DELETE, Path: []string{"0", "tset"}, From: "456"},
-		// 	},
-		// 	nil,
-		// },
-		// {
-		// 	"map-interface-slice-update", &[]map[string]interface{}{{"test": nil}}, &[]map[string]interface{}{{"test": "456"}},
-		// 	Changelog{
-		// 		Change{Type: UPDATE, Path: []string{"0", "test"}, From: nil, To: "456"},
-		// 	},
-		// 	nil,
-		// },
-		// {
-		// 	"map-nil", &map[string]string{"one": "test"}, nil,
-		// 	Changelog{
-		// 		Change{Type: DELETE, Path: []string{"\xa3one"}, From: "test", To: nil},
-		// 	},
-		// 	nil,
-		// },
-		// {
-		// 	"nil-map", nil, &map[string]string{"one": "test"},
-		// 	Changelog{
-		// 		Change{Type: CREATE, Path: []string{"\xa3one"}, From: nil, To: "test"},
-		// 	},
-		// 	nil,
-		// },
-		// {
-		// 	"nested-map-insert", &map[string]map[string]string{"a": {"test": "123"}}, &map[string]map[string]string{"a": {"test": "123", "tset": "456"}},
-		// 	Changelog{
-		// 		Change{Type: CREATE, Path: []string{"a", "tset"}, To: "456"},
-		// 	},
-		// 	nil,
-		// },
-		// {
-		// 	"nested-map-interface-insert", &map[string]map[string]interface{}{"a": {"test": "123"}}, &map[string]map[string]interface{}{"a": {"test": "123", "tset": "456"}},
-		// 	Changelog{
-		// 		Change{Type: CREATE, Path: []string{"a", "tset"}, To: "456"},
-		// 	},
-		// 	nil,
-		// },
-		// {
-		// 	"nested-map-update", &map[string]map[string]string{"a": {"test": "123"}}, &map[string]map[string]string{"a": {"test": "456"}},
-		// 	Changelog{
-		// 		Change{Type: UPDATE, Path: []string{"a", "test"}, From: "123", To: "456"},
-		// 	},
-		// 	nil,
-		// },
-		// {
-		// 	"nested-map-delete", &map[string]map[string]string{"a": {"test": "123"}}, &map[string]map[string]string{"a": {}},
-		// 	Changelog{
-		// 		Change{Type: DELETE, Path: []string{"a", "test"}, From: "123", To: nil},
-		// 	},
-		// 	nil,
-		// },
-		// {
-		// 	"nested-slice-insert", &map[string][]int{"a": {1, 2, 3}}, &map[string][]int{"a": {1, 2, 3, 4}},
-		// 	Changelog{
-		// 		Change{Type: CREATE, Path: []string{"a", "3"}, To: 4},
-		// 	},
-		// 	nil,
-		// },
-		// {
-		// 	"nested-slice-update", &map[string][]int{"a": {1, 2, 3}}, &map[string][]int{"a": {1, 4, 3}},
-		// 	Changelog{
-		// 		Change{Type: UPDATE, Path: []string{"a", "1"}, From: 2, To: 4},
-		// 	},
-		// 	nil,
-		// },
-		// {
-		// 	"nested-slice-delete", &map[string][]int{"a": {1, 2, 3}}, &map[string][]int{"a": {1, 3}},
-		// 	Changelog{
-		// 		Change{Type: DELETE, Path: []string{"a", "1"}, From: 2, To: nil},
-		// 	},
-		// 	nil,
-		// },
 		{
 			"struct-string-update", &tstruct{Name: "one"}, &tstruct{Name: "two"},
 			Changelog{
@@ -223,20 +116,6 @@ func TestPatch(t *testing.T) {
 			},
 			nil,
 		},
-		// {
-		// 	"struct-map-update", &tstruct{Map: map[string]string{"test": "123"}}, &tstruct{Map: map[string]string{"test": "456"}},
-		// 	Changelog{
-		// 		Change{Type: UPDATE, Path: []string{"map", "test"}, From: "123", To: "456"},
-		// 	},
-		// 	nil,
-		// },
-		// {
-		// 	"struct-string-pointer-update", &tstruct{Pointer: sptr("test")}, &tstruct{Pointer: sptr("test2")},
-		// 	Changelog{
-		// 		Change{Type: UPDATE, Path: []string{"pointer"}, From: "test", To: "test2"},
-		// 	},
-		// 	nil,
-		// },
 		{
 			"struct-nil-string-pointer-update", &tstruct{Pointer: nil}, &tstruct{Pointer: sptr("test")},
 			Changelog{
@@ -251,14 +130,6 @@ func TestPatch(t *testing.T) {
 			},
 			nil,
 		},
-		// {
-		// 	"struct-identifiable-slice-insert", &tstruct{Identifiables: []tistruct{{"one", 1}}}, &tstruct{Identifiables: []tistruct{{"one", 1}, {"two", 2}}},
-		// 	Changelog{
-		// 		Change{Type: CREATE, Path: []string{"identifiables", "two", "name"}, From: nil, To: "two"},
-		// 		Change{Type: CREATE, Path: []string{"identifiables", "two", "value"}, From: nil, To: 2},
-		// 	},
-		// 	nil,
-		// },
 		{
 			"struct-generic-slice-delete", &tstruct{Values: []string{"one", "two"}}, &tstruct{Values: []string{"one"}},
 			Changelog{
@@ -266,14 +137,6 @@ func TestPatch(t *testing.T) {
 			},
 			nil,
 		},
-		// {
-		// 	"struct-identifiable-slice-delete", &tstruct{Identifiables: []tistruct{{"one", 1}, {"two", 2}}}, &tstruct{Identifiables: []tistruct{{"one", 1}}},
-		// 	Changelog{
-		// 		Change{Type: DELETE, Path: []string{"identifiables", "two", "name"}, From: "two", To: nil},
-		// 		Change{Type: DELETE, Path: []string{"identifiables", "two", "value"}, From: 2, To: nil},
-		// 	},
-		// 	nil,
-		// },
 		{
 			"struct-unidentifiable-slice-insert-delete", &tstruct{Unidentifiables: []tuistruct{{1}, {2}, {3}}}, &tstruct{Unidentifiables: []tuistruct{{5}, {2}, {3}, {4}}},
 			Changelog{
@@ -299,44 +162,6 @@ func TestPatch(t *testing.T) {
 			},
 			nil,
 		},
-		// {
-		// 	"mixed-slice-map", &[]map[string]interface{}{{"name": "name1", "type": []string{"null", "string"}}}, &[]map[string]interface{}{{"name": "name1", "type": []string{"null", "int"}}, {"name": "name2", "type": []string{"null", "string"}}},
-		// 	Changelog{
-		// 		Change{Type: UPDATE, Path: []string{"0", "type", "1"}, From: "string", To: "int"},
-		// 		Change{Type: CREATE, Path: []string{"1", "\xa4name"}, From: nil, To: "name2"},
-		// 		Change{Type: CREATE, Path: []string{"1", "\xa4type"}, From: nil, To: []string{"null", "string"}},
-		// 	},
-		// 	nil,
-		// },
-		// {
-		// 	"map-string-pointer-create",
-		// 	&map[string]*tmstruct{"one": &struct1},
-		// 	&map[string]*tmstruct{"one": &struct1, "two": &struct2},
-		// 	Changelog{
-		// 		Change{Type: CREATE, Path: []string{"two", "foo"}, From: nil, To: "two"},
-		// 		Change{Type: CREATE, Path: []string{"two", "bar"}, From: nil, To: 2},
-		// 	},
-		// 	nil,
-		// },
-		// {
-		// 	"map-string-pointer-delete",
-		// 	&map[string]*tmstruct{"one": &struct1, "two": &struct2},
-		// 	&map[string]*tmstruct{"one": &struct1},
-		// 	Changelog{
-		// 		Change{Type: DELETE, Path: []string{"two", "foo"}, From: "two", To: nil},
-		// 		Change{Type: DELETE, Path: []string{"two", "bar"}, From: 2, To: nil},
-		// 	},
-		// 	nil,
-		// },
-		// {
-		// 	"private-struct-field",
-		// 	&tstruct{private: 1},
-		// 	&tstruct{private: 4},
-		// 	Changelog{
-		// 		Change{Type: UPDATE, Path: []string{"private"}, From: int64(1), To: int64(4)},
-		// 	},
-		// 	nil,
-		// },
 		{
 			"embedded-struct-field",
 			&embedstruct{Embedded{Foo: "a", Bar: 2}, true},

--- a/patch_test.go
+++ b/patch_test.go
@@ -339,8 +339,8 @@ func TestPatch(t *testing.T) {
 		// },
 		{
 			"embedded-struct-field",
-			&embedstruct{Tmstruct{Foo: "a", Bar: 2}, true},
-			&embedstruct{Tmstruct{Foo: "b", Bar: 3}, false},
+			&embedstruct{Embedded{Foo: "a", Bar: 2}, true},
+			&embedstruct{Embedded{Foo: "b", Bar: 3}, false},
 			Changelog{
 				Change{Type: UPDATE, Path: []string{"foo"}, From: "a", To: "b"},
 				Change{Type: UPDATE, Path: []string{"bar"}, From: 2, To: 3},

--- a/patch_test.go
+++ b/patch_test.go
@@ -182,12 +182,14 @@ func TestPatch(t *testing.T) {
 			switch tc.Name {
 			case "mixed-slice-map", "nil-map", "map-nil":
 				options = append(options, StructMapKeySupport())
+			case "embedded-struct-field":
+				options = append(options, FlattenEmbeddedStructs(true))
 			}
 			d, err := NewDiffer(options...)
 			if err != nil {
 				panic(err)
 			}
-			pl := d.Patch(tc.Changelog, &tc.A)
+			pl := d.Patch(tc.Changelog, tc.A)
 
 			assert.Equal(t, tc.B, tc.A)
 			require.Equal(t, len(tc.Changelog), len(pl))

--- a/patch_test.go
+++ b/patch_test.go
@@ -1,0 +1,371 @@
+package diff
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPatch(t *testing.T) {
+	cases := []struct {
+		Name      string
+		A, B      interface{}
+		Changelog Changelog
+		Error     error
+	}{
+		{
+			"uint-slice-insert", &[]uint{1, 2, 3}, &[]uint{1, 2, 3, 4},
+			Changelog{
+				Change{Type: CREATE, Path: []string{"3"}, To: uint(4)},
+			},
+			nil,
+		},
+		{
+			"int-slice-insert", &[]int{1, 2, 3}, &[]int{1, 2, 3, 4},
+			Changelog{
+				Change{Type: CREATE, Path: []string{"3"}, To: 4},
+			},
+			nil,
+		},
+		{
+			"uint-slice-delete", &[]uint{1, 2, 3}, &[]uint{1, 3},
+			Changelog{
+				Change{Type: DELETE, Path: []string{"1"}, From: uint(2)},
+			},
+			nil,
+		},
+		{
+			"int-slice-delete", &[]int{1, 2, 3}, &[]int{1, 3},
+			Changelog{
+				Change{Type: DELETE, Path: []string{"1"}, From: 2},
+			},
+			nil,
+		},
+		{
+			"uint-slice-insert-delete", &[]uint{1, 2, 3}, &[]uint{1, 3, 4},
+			Changelog{
+				Change{Type: DELETE, Path: []string{"1"}, From: uint(2)},
+				Change{Type: CREATE, Path: []string{"2"}, To: uint(4)},
+			},
+			nil,
+		},
+		{
+			"int-slice-insert-delete", &[]int{1, 2, 3}, &[]int{1, 3, 4},
+			Changelog{
+				Change{Type: DELETE, Path: []string{"1"}, From: 2},
+				Change{Type: CREATE, Path: []string{"2"}, To: 4},
+			},
+			nil,
+		},
+		{
+			"string-slice-insert", &[]string{"1", "2", "3"}, &[]string{"1", "2", "3", "4"},
+			Changelog{
+				Change{Type: CREATE, Path: []string{"3"}, To: "4"},
+			},
+			nil,
+		},
+		{
+			"string-slice-delete", &[]string{"1", "2", "3"}, &[]string{"1", "3"},
+			Changelog{
+				Change{Type: DELETE, Path: []string{"1"}, From: "2"},
+			},
+			nil,
+		},
+		{
+			"string-slice-insert-delete", &[]string{"1", "2", "3"}, &[]string{"1", "3", "4"},
+			Changelog{
+				Change{Type: DELETE, Path: []string{"1"}, From: "2"},
+				Change{Type: CREATE, Path: []string{"2"}, To: "4"},
+			},
+			nil,
+		},
+		// {
+		// 	"comparable-slice-insert", &[]tistruct{{"one", 1}}, &[]tistruct{{"one", 1}, {"two", 2}},
+		// 	Changelog{
+		// 		Change{Type: CREATE, Path: []string{"two", "name"}, To: "two"},
+		// 		Change{Type: CREATE, Path: []string{"two", "value"}, To: 2},
+		// 	},
+		// 	nil,
+		// },
+		// {
+		// 	"comparable-slice-delete", &[]tistruct{{"one", 1}, {"two", 2}}, &[]tistruct{{"one", 1}},
+		// 	Changelog{
+		// 		Change{Type: DELETE, Path: []string{"two", "name"}, From: "two"},
+		// 		Change{Type: DELETE, Path: []string{"two", "value"}, From: 2},
+		// 	},
+		// 	nil,
+		// },
+		{
+			"comparable-slice-update", &[]tistruct{{"one", 1}}, &[]tistruct{{"one", 50}},
+			Changelog{
+				Change{Type: UPDATE, Path: []string{"one", "value"}, From: 1, To: 50},
+			},
+			nil,
+		},
+		// {
+		// 	"map-slice-insert", &[]map[string]string{{"test": "123"}}, &[]map[string]string{{"test": "123", "tset": "456"}},
+		// 	Changelog{
+		// 		Change{Type: CREATE, Path: []string{"0", "tset"}, To: "456"},
+		// 	},
+		// 	nil,
+		// },
+		// {
+		// 	"map-slice-update", &[]map[string]string{{"test": "123"}}, &[]map[string]string{{"test": "456"}},
+		// 	Changelog{
+		// 		Change{Type: UPDATE, Path: []string{"0", "test"}, From: "123", To: "456"},
+		// 	},
+		// 	nil,
+		// },
+		// {
+		// 	"map-slice-delete", &[]map[string]string{{"test": "123", "tset": "456"}}, &[]map[string]string{{"test": "123"}},
+		// 	Changelog{
+		// 		Change{Type: DELETE, Path: []string{"0", "tset"}, From: "456"},
+		// 	},
+		// 	nil,
+		// },
+		// {
+		// 	"map-interface-slice-update", &[]map[string]interface{}{{"test": nil}}, &[]map[string]interface{}{{"test": "456"}},
+		// 	Changelog{
+		// 		Change{Type: UPDATE, Path: []string{"0", "test"}, From: nil, To: "456"},
+		// 	},
+		// 	nil,
+		// },
+		// {
+		// 	"map-nil", &map[string]string{"one": "test"}, nil,
+		// 	Changelog{
+		// 		Change{Type: DELETE, Path: []string{"\xa3one"}, From: "test", To: nil},
+		// 	},
+		// 	nil,
+		// },
+		// {
+		// 	"nil-map", nil, &map[string]string{"one": "test"},
+		// 	Changelog{
+		// 		Change{Type: CREATE, Path: []string{"\xa3one"}, From: nil, To: "test"},
+		// 	},
+		// 	nil,
+		// },
+		// {
+		// 	"nested-map-insert", &map[string]map[string]string{"a": {"test": "123"}}, &map[string]map[string]string{"a": {"test": "123", "tset": "456"}},
+		// 	Changelog{
+		// 		Change{Type: CREATE, Path: []string{"a", "tset"}, To: "456"},
+		// 	},
+		// 	nil,
+		// },
+		// {
+		// 	"nested-map-interface-insert", &map[string]map[string]interface{}{"a": {"test": "123"}}, &map[string]map[string]interface{}{"a": {"test": "123", "tset": "456"}},
+		// 	Changelog{
+		// 		Change{Type: CREATE, Path: []string{"a", "tset"}, To: "456"},
+		// 	},
+		// 	nil,
+		// },
+		// {
+		// 	"nested-map-update", &map[string]map[string]string{"a": {"test": "123"}}, &map[string]map[string]string{"a": {"test": "456"}},
+		// 	Changelog{
+		// 		Change{Type: UPDATE, Path: []string{"a", "test"}, From: "123", To: "456"},
+		// 	},
+		// 	nil,
+		// },
+		// {
+		// 	"nested-map-delete", &map[string]map[string]string{"a": {"test": "123"}}, &map[string]map[string]string{"a": {}},
+		// 	Changelog{
+		// 		Change{Type: DELETE, Path: []string{"a", "test"}, From: "123", To: nil},
+		// 	},
+		// 	nil,
+		// },
+		// {
+		// 	"nested-slice-insert", &map[string][]int{"a": {1, 2, 3}}, &map[string][]int{"a": {1, 2, 3, 4}},
+		// 	Changelog{
+		// 		Change{Type: CREATE, Path: []string{"a", "3"}, To: 4},
+		// 	},
+		// 	nil,
+		// },
+		// {
+		// 	"nested-slice-update", &map[string][]int{"a": {1, 2, 3}}, &map[string][]int{"a": {1, 4, 3}},
+		// 	Changelog{
+		// 		Change{Type: UPDATE, Path: []string{"a", "1"}, From: 2, To: 4},
+		// 	},
+		// 	nil,
+		// },
+		// {
+		// 	"nested-slice-delete", &map[string][]int{"a": {1, 2, 3}}, &map[string][]int{"a": {1, 3}},
+		// 	Changelog{
+		// 		Change{Type: DELETE, Path: []string{"a", "1"}, From: 2, To: nil},
+		// 	},
+		// 	nil,
+		// },
+		{
+			"struct-string-update", &tstruct{Name: "one"}, &tstruct{Name: "two"},
+			Changelog{
+				Change{Type: UPDATE, Path: []string{"name"}, From: "one", To: "two"},
+			},
+			nil,
+		},
+		{
+			"struct-int-update", &tstruct{Value: 1}, &tstruct{Value: 50},
+			Changelog{
+				Change{Type: UPDATE, Path: []string{"value"}, From: 1, To: 50},
+			},
+			nil,
+		},
+		{
+			"struct-bool-update", &tstruct{Bool: true}, &tstruct{Bool: false},
+			Changelog{
+				Change{Type: UPDATE, Path: []string{"bool"}, From: true, To: false},
+			},
+			nil,
+		},
+		{
+			"struct-time-update", &tstruct{}, &tstruct{Time: currentTime},
+			Changelog{
+				Change{Type: UPDATE, Path: []string{"time"}, From: time.Time{}, To: currentTime},
+			},
+			nil,
+		},
+		// {
+		// 	"struct-map-update", &tstruct{Map: map[string]string{"test": "123"}}, &tstruct{Map: map[string]string{"test": "456"}},
+		// 	Changelog{
+		// 		Change{Type: UPDATE, Path: []string{"map", "test"}, From: "123", To: "456"},
+		// 	},
+		// 	nil,
+		// },
+		// {
+		// 	"struct-string-pointer-update", &tstruct{Pointer: sptr("test")}, &tstruct{Pointer: sptr("test2")},
+		// 	Changelog{
+		// 		Change{Type: UPDATE, Path: []string{"pointer"}, From: "test", To: "test2"},
+		// 	},
+		// 	nil,
+		// },
+		{
+			"struct-nil-string-pointer-update", &tstruct{Pointer: nil}, &tstruct{Pointer: sptr("test")},
+			Changelog{
+				Change{Type: UPDATE, Path: []string{"pointer"}, From: nil, To: sptr("test")},
+			},
+			nil,
+		},
+		{
+			"struct-generic-slice-insert", &tstruct{Values: []string{"one"}}, &tstruct{Values: []string{"one", "two"}},
+			Changelog{
+				Change{Type: CREATE, Path: []string{"values", "1"}, From: nil, To: "two"},
+			},
+			nil,
+		},
+		// {
+		// 	"struct-identifiable-slice-insert", &tstruct{Identifiables: []tistruct{{"one", 1}}}, &tstruct{Identifiables: []tistruct{{"one", 1}, {"two", 2}}},
+		// 	Changelog{
+		// 		Change{Type: CREATE, Path: []string{"identifiables", "two", "name"}, From: nil, To: "two"},
+		// 		Change{Type: CREATE, Path: []string{"identifiables", "two", "value"}, From: nil, To: 2},
+		// 	},
+		// 	nil,
+		// },
+		{
+			"struct-generic-slice-delete", &tstruct{Values: []string{"one", "two"}}, &tstruct{Values: []string{"one"}},
+			Changelog{
+				Change{Type: DELETE, Path: []string{"values", "1"}, From: "two", To: nil},
+			},
+			nil,
+		},
+		// {
+		// 	"struct-identifiable-slice-delete", &tstruct{Identifiables: []tistruct{{"one", 1}, {"two", 2}}}, &tstruct{Identifiables: []tistruct{{"one", 1}}},
+		// 	Changelog{
+		// 		Change{Type: DELETE, Path: []string{"identifiables", "two", "name"}, From: "two", To: nil},
+		// 		Change{Type: DELETE, Path: []string{"identifiables", "two", "value"}, From: 2, To: nil},
+		// 	},
+		// 	nil,
+		// },
+		{
+			"struct-unidentifiable-slice-insert-delete", &tstruct{Unidentifiables: []tuistruct{{1}, {2}, {3}}}, &tstruct{Unidentifiables: []tuistruct{{5}, {2}, {3}, {4}}},
+			Changelog{
+				Change{Type: UPDATE, Path: []string{"unidentifiables", "0", "value"}, From: 1, To: 5},
+				Change{Type: CREATE, Path: []string{"unidentifiables", "3", "value"}, From: nil, To: 4},
+			},
+			nil,
+		},
+		{
+			"slice", &tstruct{}, &tstruct{Nested: tnstruct{Slice: []tmstruct{{"one", 1}, {"two", 2}}}},
+			Changelog{
+				Change{Type: CREATE, Path: []string{"nested", "slice", "0", "foo"}, From: nil, To: "one"},
+				Change{Type: CREATE, Path: []string{"nested", "slice", "0", "bar"}, From: nil, To: 1},
+				Change{Type: CREATE, Path: []string{"nested", "slice", "1", "foo"}, From: nil, To: "two"},
+				Change{Type: CREATE, Path: []string{"nested", "slice", "1", "bar"}, From: nil, To: 2},
+			},
+			nil,
+		},
+		{
+			"slice-duplicate-items", &[]int{1}, &[]int{1, 1},
+			Changelog{
+				Change{Type: CREATE, Path: []string{"1"}, From: nil, To: 1},
+			},
+			nil,
+		},
+		// {
+		// 	"mixed-slice-map", &[]map[string]interface{}{{"name": "name1", "type": []string{"null", "string"}}}, &[]map[string]interface{}{{"name": "name1", "type": []string{"null", "int"}}, {"name": "name2", "type": []string{"null", "string"}}},
+		// 	Changelog{
+		// 		Change{Type: UPDATE, Path: []string{"0", "type", "1"}, From: "string", To: "int"},
+		// 		Change{Type: CREATE, Path: []string{"1", "\xa4name"}, From: nil, To: "name2"},
+		// 		Change{Type: CREATE, Path: []string{"1", "\xa4type"}, From: nil, To: []string{"null", "string"}},
+		// 	},
+		// 	nil,
+		// },
+		// {
+		// 	"map-string-pointer-create",
+		// 	&map[string]*tmstruct{"one": &struct1},
+		// 	&map[string]*tmstruct{"one": &struct1, "two": &struct2},
+		// 	Changelog{
+		// 		Change{Type: CREATE, Path: []string{"two", "foo"}, From: nil, To: "two"},
+		// 		Change{Type: CREATE, Path: []string{"two", "bar"}, From: nil, To: 2},
+		// 	},
+		// 	nil,
+		// },
+		// {
+		// 	"map-string-pointer-delete",
+		// 	&map[string]*tmstruct{"one": &struct1, "two": &struct2},
+		// 	&map[string]*tmstruct{"one": &struct1},
+		// 	Changelog{
+		// 		Change{Type: DELETE, Path: []string{"two", "foo"}, From: "two", To: nil},
+		// 		Change{Type: DELETE, Path: []string{"two", "bar"}, From: 2, To: nil},
+		// 	},
+		// 	nil,
+		// },
+		// {
+		// 	"private-struct-field",
+		// 	&tstruct{private: 1},
+		// 	&tstruct{private: 4},
+		// 	Changelog{
+		// 		Change{Type: UPDATE, Path: []string{"private"}, From: int64(1), To: int64(4)},
+		// 	},
+		// 	nil,
+		// },
+		{
+			"embedded-struct-field",
+			&embedstruct{Tmstruct{Foo: "a", Bar: 2}, true},
+			&embedstruct{Tmstruct{Foo: "b", Bar: 3}, false},
+			Changelog{
+				Change{Type: UPDATE, Path: []string{"foo"}, From: "a", To: "b"},
+				Change{Type: UPDATE, Path: []string{"bar"}, From: 2, To: 3},
+				Change{Type: UPDATE, Path: []string{"baz"}, From: true, To: false},
+			},
+			nil,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+
+			var options []func(d *Differ) error
+			switch tc.Name {
+			case "mixed-slice-map", "nil-map", "map-nil":
+				options = append(options, StructMapKeySupport())
+			}
+			d, err := NewDiffer(options...)
+			if err != nil {
+				panic(err)
+			}
+			pl := d.Patch(tc.Changelog, &tc.A)
+
+			assert.Equal(t, tc.B, tc.A)
+			require.Equal(t, len(tc.Changelog), len(pl))
+		})
+	}
+}


### PR DESCRIPTION
When diffing objects it is often desirable to have the diff reflect the JSON representation of the object as closely as possible. This PR adds an option `FlattenEmbeddedStructs(enabled bool)` that can be set to make both `Diff()` and `Patch()` behave as though members of embedded structs were actually members of the containing struct, as `json.Marshal()` does.

In the documentation for `json.Marshal()` such fields are called [Anonymous](https://golang.org/pkg/encoding/json/#Marshal), while in the golang spec they are called [Embedded fields](https://golang.org/ref/spec#EmbeddedField). I used embedded, but if you think anonymous is clearer I'll change it.

I also added `patch_test.go` that is basically just a copy of `diff_test.go`. Instead of diffing the two objects in each test case and verifying that the changelog contains the given changes, it applies the changelog to the first object and verifies that the result is equal to the second object. Quite a few tests failed - I'm unsure if it's because I did something wrong or there's still some cases that `Patch()` doesn't handle. In case it's missing functionality, I left the failing test cases and commented them out so we can keep track of what's still missing.