### PR TITLE
Add option to convert between compatible types

### DIFF
--- a/diff.go
+++ b/diff.go
@@ -34,6 +34,7 @@ type Differ struct {
 	DiscardParent          bool
 	StructMapKeys          bool
 	FlattenEmbeddedStructs bool
+	ConvertCompatibleTypes bool
 	Filter                 FilterFunc
 }
 
@@ -252,11 +253,11 @@ func swapChange(t string, c Change) Change {
 }
 
 func idComplex(v interface{}) string {
-	switch v.(type) {
+	switch v := v.(type) {
 	case string:
-		return v.(string)
+		return v
 	case int:
-		return strconv.Itoa(v.(int))
+		return strconv.Itoa(v)
 	default:
 		b, err := msgpack.Marshal(v)
 		if err != nil {
@@ -267,11 +268,11 @@ func idComplex(v interface{}) string {
 
 }
 func idstring(v interface{}) string {
-	switch v.(type) {
+	switch v := v.(type) {
 	case string:
-		return v.(string)
+		return v
 	case int:
-		return strconv.Itoa(v.(int))
+		return strconv.Itoa(v)
 	default:
 		return fmt.Sprint(v)
 	}

--- a/diff_map.go
+++ b/diff_map.go
@@ -6,8 +6,9 @@ package diff
 
 import (
 	"fmt"
-	"github.com/vmihailenco/msgpack"
 	"reflect"
+
+	"github.com/vmihailenco/msgpack"
 )
 
 func (d *Differ) diffMap(path []string, a, b reflect.Value) error {
@@ -57,7 +58,8 @@ func (d *Differ) mapValues(t string, path []string, a reflect.Value) error {
 		if d.StructMapKeys {
 			//it's not enough to turn k to a string, we need to able to  marshal a type when
 			//we apply it in patch so... we'll marshal it to JSON
-			if b, err := msgpack.Marshal(k.Interface()); err == nil {
+			var b []byte
+			if b, err = msgpack.Marshal(k.Interface()); err == nil {
 				err = d.diff(append(path, string(b)), xe, ae, a.Interface())
 			}
 		} else {

--- a/diff_slice.go
+++ b/diff_slice.go
@@ -90,7 +90,7 @@ type sliceTracker []bool
 
 func (st *sliceTracker) has(s, v reflect.Value) bool {
 	if len(*st) != s.Len() {
-		(*st) = make([]bool, s.Len(), s.Len())
+		(*st) = make([]bool, s.Len())
 	}
 
 	for i := 0; i < s.Len(); i++ {

--- a/diff_string.go
+++ b/diff_string.go
@@ -22,7 +22,12 @@ func (d *Differ) diffString(path []string, a, b reflect.Value, parent interface{
 	}
 
 	if a.String() != b.String() {
-		d.cl.Add(UPDATE, path, a.String(), b.String(), parent)
+		if a.CanInterface() {
+			// If a and/or b is of a type that is an alias for String, store that type in changelog
+			d.cl.Add(UPDATE, path, a.Interface(), b.Interface(), parent)
+		} else {
+			d.cl.Add(UPDATE, path, a.String(), b.String(), parent)
+		}
 	}
 
 	return nil

--- a/diff_struct.go
+++ b/diff_struct.go
@@ -46,7 +46,7 @@ func (d *Differ) diffStruct(path []string, a, b reflect.Value) error {
 		bf := b.FieldByName(field.Name)
 
 		fpath := path
-		if !field.Anonymous {
+		if !(d.FlattenEmbeddedStructs && field.Anonymous) {
 			fpath = copyAppend(fpath, tname)
 		}
 

--- a/diff_test.go
+++ b/diff_test.go
@@ -46,6 +46,18 @@ type embedstruct struct {
 	Baz bool `diff:"baz"`
 }
 
+type customTagStruct struct {
+	Foo string `json:"foo"`
+	Bar int    `json:"bar"`
+}
+
+type CustomStringType string
+type CustomIntType int
+type customTypeStruct struct {
+	Foo CustomStringType `diff:"foo"`
+	Bar CustomIntType    `diff:"bar"`
+}
+
 type tstruct struct {
 	ID              string            `diff:"id,immutable"`
 	Name            string            `diff:"name"`
@@ -233,21 +245,21 @@ func TestDiff(t *testing.T) {
 			nil,
 		},
 		{
-			"nested-slice-insert", map[string][]int{"a": []int{1, 2, 3}}, map[string][]int{"a": []int{1, 2, 3, 4}},
+			"nested-slice-insert", map[string][]int{"a": {1, 2, 3}}, map[string][]int{"a": {1, 2, 3, 4}},
 			Changelog{
 				Change{Type: CREATE, Path: []string{"a", "3"}, To: 4},
 			},
 			nil,
 		},
 		{
-			"nested-slice-update", map[string][]int{"a": []int{1, 2, 3}}, map[string][]int{"a": []int{1, 4, 3}},
+			"nested-slice-update", map[string][]int{"a": {1, 2, 3}}, map[string][]int{"a": {1, 4, 3}},
 			Changelog{
 				Change{Type: UPDATE, Path: []string{"a", "1"}, From: 2, To: 4},
 			},
 			nil,
 		},
 		{
-			"nested-slice-delete", map[string][]int{"a": []int{1, 2, 3}}, map[string][]int{"a": []int{1, 3}},
+			"nested-slice-delete", map[string][]int{"a": {1, 2, 3}}, map[string][]int{"a": {1, 3}},
 			Changelog{
 				Change{Type: DELETE, Path: []string{"a", "1"}, From: 2, To: nil},
 			},
@@ -416,6 +428,26 @@ func TestDiff(t *testing.T) {
 			},
 			nil,
 		},
+		{
+			"custom-tags",
+			customTagStruct{Foo: "abc", Bar: 3},
+			customTagStruct{Foo: "def", Bar: 4},
+			Changelog{
+				Change{Type: UPDATE, Path: []string{"foo"}, From: "abc", To: "def"},
+				Change{Type: UPDATE, Path: []string{"bar"}, From: 3, To: 4},
+			},
+			nil,
+		},
+		{
+			"custom-types",
+			customTypeStruct{Foo: "a", Bar: 1},
+			customTypeStruct{Foo: "b", Bar: 2},
+			Changelog{
+				Change{Type: UPDATE, Path: []string{"foo"}, From: CustomStringType("a"), To: CustomStringType("b")},
+				Change{Type: UPDATE, Path: []string{"bar"}, From: CustomIntType(1), To: CustomIntType(2)},
+			},
+			nil,
+		},
 	}
 
 	for _, tc := range cases {
@@ -425,6 +457,10 @@ func TestDiff(t *testing.T) {
 			switch tc.Name {
 			case "mixed-slice-map", "nil-map", "map-nil":
 				options = append(options, StructMapKeySupport())
+			case "embedded-struct-field":
+				options = append(options, FlattenEmbeddedStructs())
+			case "custom-tags":
+				options = append(options, TagName("json"))
 			}
 			cl, err := Diff(tc.A, tc.B, options...)
 
@@ -505,7 +541,7 @@ func TestDiffSliceOrdering(t *testing.T) {
 			nil,
 		},
 		{
-			"nested-slice-delete", map[string][]int{"a": []int{1, 2, 3}}, map[string][]int{"a": []int{1, 3}},
+			"nested-slice-delete", map[string][]int{"a": {1, 2, 3}}, map[string][]int{"a": {1, 3}},
 			Changelog{
 				Change{Type: UPDATE, Path: []string{"a", "1"}, From: 2, To: 3},
 				Change{Type: DELETE, Path: []string{"a", "2"}, From: 3},
@@ -771,7 +807,7 @@ func TestRecursiveCustomDiffer(t *testing.T) {
 	treeB := RecursiveTestStruct{
 		Id: 1,
 		Children: []RecursiveTestStruct{
-			RecursiveTestStruct{
+			{
 				Id:       4,
 				Children: []RecursiveTestStruct{},
 			},

--- a/error.go
+++ b/error.go
@@ -68,7 +68,7 @@ func NewError(message string, causes ...error) *DiffError {
 		message: message,
 	}
 	for _, cause := range causes {
-		s.WithCause(cause)
+		s.WithCause(cause) // nolint: errcheck
 	}
 	return s
 }

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/r3labs/diff/v2
+module github.com/j0s/diff/v2
 
 go 1.13
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/j0s/diff/v2
+module github.com/r3labs/diff/v2
 
 go 1.13
 

--- a/options.go
+++ b/options.go
@@ -1,9 +1,17 @@
 package diff
 
-// FlattenEmbeddedStructs determines whether fields of embedded structs should behave as if they are directly under the parent
-func FlattenEmbeddedStructs(enabled bool) func(d *Differ) error {
+// ConvertTypes enables values that are convertible to the target type to be converted when patching
+func ConvertCompatibleTypes() func(d *Differ) error {
 	return func(d *Differ) error {
-		d.FlattenEmbeddedStructs = enabled
+		d.ConvertCompatibleTypes = true
+		return nil
+	}
+}
+
+// FlattenEmbeddedStructs determines whether fields of embedded structs should behave as if they are directly under the parent
+func FlattenEmbeddedStructs() func(d *Differ) error {
+	return func(d *Differ) error {
+		d.FlattenEmbeddedStructs = true
 		return nil
 	}
 }
@@ -37,7 +45,7 @@ func DisableStructValues() func(d *Differ) error {
 func CustomValueDiffers(vd ...ValueDiffer) func(d *Differ) error {
 	return func(d *Differ) error {
 		d.customValueDiffers = append(d.customValueDiffers, vd...)
-		for k, _ := range d.customValueDiffers {
+		for k := range d.customValueDiffers {
 			d.customValueDiffers[k].InsertParentDiffer(d.diff)
 		}
 		return nil

--- a/patch.go
+++ b/patch.go
@@ -115,7 +115,7 @@ func Merge(original interface{}, changed interface{}, target interface{}) (Patch
 // Merge is a convenience function that diffs, the original and changed items
 // and merges said changes with target all in one call.
 func (d *Differ) Merge(original interface{}, changed interface{}, target interface{}) (PatchLog, error) {
-	StructMapKeySupport()(d)
+	StructMapKeySupport()(d) // nolint: errcheck
 	if cl, err := d.Diff(original, changed); err == nil {
 		return Patch(cl, target), nil
 	} else {
@@ -221,7 +221,7 @@ func (d *Differ) renderChangeTarget(c *ChangeValue) {
 		case UPDATE, CREATE:
 			// this is generic because... we only deal in primitives here. AND
 			// the diff format To field already contains the correct type.
-			c.Set(reflect.ValueOf(c.change.To))
+			c.Set(reflect.ValueOf(c.change.To), d.ConvertCompatibleTypes)
 			c.SetFlag(FlagUpdated)
 		}
 	}

--- a/patch_slice.go
+++ b/patch_slice.go
@@ -53,12 +53,12 @@ func (d *Differ) renderSlice(c *ChangeValue) {
 func (d *Differ) deleteSliceEntry(c *ChangeValue) {
 	//for a slice with only one element
 	if c.ParentLen() == 1 && c.index != -1 {
-		c.ParentSet(reflect.MakeSlice(c.parent.Type(), 0, 0))
+		c.ParentSet(reflect.MakeSlice(c.parent.Type(), 0, 0), d.ConvertCompatibleTypes)
 		c.SetFlag(FlagDeleted)
 		//for a slice with multiple elements
 	} else if c.index != -1 { //this is an array delete the element from the parent
 		c.ParentIndex(c.index).Set(c.ParentIndex(c.ParentLen() - 1))
-		c.ParentSet(c.parent.Slice(0, c.ParentLen()-1))
+		c.ParentSet(c.parent.Slice(0, c.ParentLen()-1), d.ConvertCompatibleTypes)
 		c.SetFlag(FlagDeleted)
 		//for other slice elements, we ignore
 	} else {

--- a/patch_struct.go
+++ b/patch_struct.go
@@ -62,5 +62,5 @@ func (d *Differ) patchStruct(c *ChangeValue) {
 func (d *Differ) deleteStructEntry(c *ChangeValue) {
 
 	//deleting a struct value set's it to the 'basic' type
-	c.Set(reflect.Zero(c.target.Type()))
+	c.Set(reflect.Zero(c.target.Type()), d.ConvertCompatibleTypes)
 }


### PR DESCRIPTION
- Fix bug from my previous PR that made Patch always behave as if `FlattenEmbeddedStructs` was set
- Add option `ConvertCompatibleTypes` that makes Patch convert between
compatible types when applying changes
- Make Diff store specific type in changelog if the type is an alias
for string. Previously they were just stored as string.
- Various linting fixes