### PR TITLE
fix calling interface on struct values that are private

### DIFF
--- a/diff_struct.go
+++ b/diff_struct.go
@@ -54,6 +54,11 @@ func (d *Differ) diffStruct(path []string, a, b reflect.Value) error {
 			continue
 		}
 
+		// skip private fields
+		if !a.CanInterface() {
+			continue
+		}
+
 		err := d.diff(fpath, af, bf, a.Interface())
 		if err != nil {
 			return err

--- a/diff_test.go
+++ b/diff_test.go
@@ -6,6 +6,7 @@ package diff
 
 import (
 	"reflect"
+	"sync"
 	"testing"
 	"time"
 
@@ -49,6 +50,11 @@ type embedstruct struct {
 type customTagStruct struct {
 	Foo string `json:"foo"`
 	Bar int    `json:"bar"`
+}
+
+type privateValueStruct struct {
+	Public  string
+	Private *sync.RWMutex
 }
 
 type CustomStringType string
@@ -349,6 +355,13 @@ func TestDiff(t *testing.T) {
 			Changelog{
 				Change{Type: UPDATE, Path: []string{"unidentifiables", "0", "value"}, From: 1, To: 5},
 				Change{Type: CREATE, Path: []string{"unidentifiables", "3", "value"}, From: nil, To: 4},
+			},
+			nil,
+		},
+		{
+			"struct-with-private-value", privateValueStruct{Public: "one", Private: new(sync.RWMutex)}, privateValueStruct{Public: "two", Private: new(sync.RWMutex)},
+			Changelog{
+				Change{Type: UPDATE, Path: []string{"Public"}, From: "one", To: "two"},
 			},
 			nil,
 		},


### PR DESCRIPTION
- [x] Skip struct values that do not allow us to call `Interface()` on them

Fixes #57 