### PR TITLE
Allow ValueDiffers in nested structs

### DIFF
--- a/diff_struct.go
+++ b/diff_struct.go
@@ -71,6 +71,7 @@ func (d *Differ) diffStruct(path []string, a, b reflect.Value) error {
 func (d *Differ) structValues(t string, path []string, a reflect.Value) error {
 	var nd Differ
 	nd.Filter = d.Filter
+	nd.customValueDiffers = d.customValueDiffers
 
 	if t != CREATE && t != DELETE {
 		return ErrInvalidChangeType


### PR DESCRIPTION
Allow customValueDiffers in nested structs

```go
type uuid.UUID [16]byte

type uuidDiff struct{}
// diff implementation that diffs uuids with uuid.String()

type S2 struct {
    Test uuid.UUID
}

type S1 struct {
    Test uuid.UUID
    Inner *S2
}

func diff() {
   s1 := S1{}
   s2 := S2{Test: uuid.New(), Inner: S2{Test: uuid.New()}}
   changelog, _ := diff.Diff(s1, s2, diff.CustomValueDiffers(&uuidDiff{}))
   // changelog has ~17 changes
   // 16 of s2.Inner.Test
   // 1 of s2.Test
}

```