### PR TITLE
Added DiffType and DiffFunc to ValueDiffer interface

### DIFF
--- a/diff_map.go
+++ b/diff_map.go
@@ -11,7 +11,7 @@ import (
 	"github.com/vmihailenco/msgpack"
 )
 
-func (d *Differ) diffMap(path []string, a, b reflect.Value) error {
+func (d *Differ) diffMap(path []string, a, b reflect.Value, parent interface{}) error {
 	if a.Kind() == reflect.Invalid {
 		return d.mapValues(CREATE, path, b)
 	}

--- a/diff_slice.go
+++ b/diff_slice.go
@@ -8,7 +8,7 @@ import (
 	"reflect"
 )
 
-func (d *Differ) diffSlice(path []string, a, b reflect.Value) error {
+func (d *Differ) diffSlice(path []string, a, b reflect.Value, parent interface{}) error {
 	if a.Kind() == reflect.Invalid {
 		d.cl.Add(CREATE, path, nil, exportInterface(b))
 		return nil

--- a/diff_struct.go
+++ b/diff_struct.go
@@ -9,7 +9,7 @@ import (
 	"time"
 )
 
-func (d *Differ) diffStruct(path []string, a, b reflect.Value) error {
+func (d *Differ) diffStruct(path []string, a, b reflect.Value, parent interface{}) error {
 	if AreType(a, b, reflect.TypeOf(time.Time{})) {
 		return d.diffTime(path, a, b)
 	}


### PR DESCRIPTION
Proposal: Add the ability to intercept data using custom differs alongside the ability to continue the original diff logic
Added two new parameters to ValueDiffer interface "Diff" function: "DiffType" and "DiffFunc"

- DiffType: represents the diff type (string, int, float, map, slice...) It's really useful to have that information when creating a custom differ, to make sure we are handling the right data type inside the custom differ
- DiffFunc: represents the original built-int diff func used by the lib. It's needed if we want to intercept the data and continue the "normal" diff logic, or just add some custom changelog logic and continue the original logic

My initial idea was to make the built-in functions public, but I think modifying the ValueDiffer interface is better and less confusing, also having the DiffType and DiffFunc parameters in hand is really useful.

Real cases motivation:
[https://github.com/up9inc/oas-diff/blob/b97eb1f97c671a24e2abf3ee3a0b4cf29fb9049c/differentiator/parametersDiffer.go#L31](https://github.com/up9inc/oas-diff/blob/b97eb1f97c671a24e2abf3ee3a0b4cf29fb9049c/differentiator/parametersDiffer.go#L31)
[https://github.com/up9inc/oas-diff/blob/b97eb1f97c671a24e2abf3ee3a0b4cf29fb9049c/differentiator/stringDiffer.go#L28](https://github.com/up9inc/oas-diff/blob/b97eb1f97c671a24e2abf3ee3a0b4cf29fb9049c/differentiator/stringDiffer.go#L28)

Please let me know your opinion if we can handle it another way, or do it better
Thanks