### PR TITLE
fix: report create/delete differences on empty structs

### DIFF
--- a/diff_struct.go
+++ b/diff_struct.go
@@ -85,6 +85,20 @@ func (d *Differ) structValues(t string, path []string, a reflect.Value) error {
 		return ErrTypeMismatch
 	}
 
+	// empty struct
+	// add to changelog and return
+	if a.NumField() == 0 {
+		var from, to interface{}
+
+		from, to = nil, exportInterface(a)
+		if t == DELETE {
+			from, to = to, nil
+		}
+
+		d.cl.Add(t, path, from, to)
+		return nil
+	}
+
 	x := reflect.New(a.Type()).Elem()
 
 	for i := 0; i < a.NumField(); i++ {

--- a/diff_test.go
+++ b/diff_test.go
@@ -618,6 +618,20 @@ func TestDiff(t *testing.T) {
 			diff.Changelog{},
 			nil,
 		},
+		{
+			"map-empty-struct-value",
+			map[string]struct{}{
+				"one": {},
+			},
+			map[string]struct{}{
+				"two": {},
+			},
+			diff.Changelog{
+				diff.Change{Type: diff.DELETE, Path: []string{"one"}, From: struct{}{}, To: nil},
+				diff.Change{Type: diff.CREATE, Path: []string{"two"}, From: nil, To: struct{}{}},
+			},
+			nil,
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
closes #100 

to address this issue I've added an eager return inside `structValues` that, if the struct has no fields, appends a single entry to the changelog for the struct itself; also added tests for this

```go
wants, got := Set{"one": {}}, Set{} 
diff.Diff(wants, got)

diff.Changelog{
	diff.Change{
		Type: diff.DELETE,
		Path: []string{"one"},
		From: struct{}{},
		To: nil,
	},
}
```