### PR TITLE
Support cyclic types

### DIFF
--- a/diff.go
+++ b/diff.go
@@ -86,6 +86,7 @@ type Differ struct {
 	FlattenEmbeddedStructs bool
 	ConvertCompatibleTypes bool
 	Filter                 FilterFunc
+	pointersSeen           map[uintptr]map[uintptr]struct{}
 }
 
 // Changelog stores a list of changed items
@@ -127,6 +128,7 @@ func NewDiffer(opts ...func(d *Differ) error) (*Differ, error) {
 	d := Differ{
 		TagName:       "diff",
 		DiscardParent: false,
+		pointersSeen:  make(map[uintptr]map[uintptr]struct{}),
 	}
 
 	for _, opt := range opts {
@@ -222,7 +224,6 @@ func (d *Differ) Diff(a, b interface{}) (Changelog, error) {
 }
 
 func (d *Differ) diff(path []string, a, b reflect.Value, parent interface{}) error {
-
 	//look and see if we need to discard the parent
 	if parent != nil {
 		if d.DiscardParent || reflect.TypeOf(parent).Kind() != reflect.Struct {

--- a/diff_slice.go
+++ b/diff_slice.go
@@ -104,6 +104,7 @@ func (st *sliceTracker) has(s, v reflect.Value, d *Differ) bool {
 		var nd Differ
 		nd.Filter = d.Filter
 		nd.customValueDiffers = d.customValueDiffers
+		nd.pointersSeen = d.pointersSeen
 
 		err := nd.diff([]string{}, x, v, nil)
 		if err != nil {

--- a/diff_struct.go
+++ b/diff_struct.go
@@ -72,6 +72,7 @@ func (d *Differ) structValues(t string, path []string, a reflect.Value) error {
 	var nd Differ
 	nd.Filter = d.Filter
 	nd.customValueDiffers = d.customValueDiffers
+	nd.pointersSeen = d.pointersSeen
 
 	if t != CREATE && t != DELETE {
 		return ErrInvalidChangeType


### PR DESCRIPTION
Presently, calling Diff() on a self-referential value will never return.

This patch records all pointer comparisons, and before each pointer comparison, if a comparison has happened before during the same diff, indicating a cycle was detected, then the comparison does nothing.

This mimics how the standard libraries [DeepEqual](https://pkg.go.dev/reflect#DeepEqual) function works.